### PR TITLE
usage: restrict to package-level methods

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -32,7 +32,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-#load-plugins=pylint_pytest,pylint_plugin_disable
+#load-plugins=pylint_plugin_disable
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -177,7 +177,7 @@ disable=format,
         multiple-imports,
         # we use it to speedup/optimize
         import-outside-toplevel,
-        fixme,
+        protected-access
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/dvclive/keras.py
+++ b/dvclive/keras.py
@@ -1,6 +1,6 @@
 from tensorflow.keras.callbacks import Callback
 
-from dvclive import dvclive
+import dvclive
 from dvclive.dvc import make_checkpoint
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ tests_requires = [
     "pytest>=6.0.1",
     "pre-commit",
     "pylint",
+    "pylint-plugin-utils",
     "black",
     "flake8",
     "pytest-cov",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,8 @@ import pytest
 
 @pytest.fixture
 def tmp_dir(tmp_path, monkeypatch):
+    import dvclive
+
+    dvclive._metric_logger = None  # pylint: disable=protected-access
     monkeypatch.chdir(tmp_path)
     yield tmp_path


### PR DESCRIPTION
We used to have a way of initialization that was resulting in not-idempotent behavior. Relying on a constant `DvcLive` object that had `init` method (and not using `__init__`) was making it stateful and could lead to some unobvious errors, when using `dvclive` in situation when initializing multiple times was possible. For example, jupyter notebook and cell re-execution. This PR intends to fix that
Fixes #15 