### PR TITLE
init: throw on dvc/dvclive config mismatch

### DIFF
--- a/dvclive/error.py
+++ b/dvclive/error.py
@@ -1,3 +1,10 @@
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .metrics import MetricLogger
+
+
 class DvcLiveError(Exception):
     pass
 
@@ -7,4 +14,14 @@ class InitializationError(DvcLiveError):
         super().__init__(
             "Initialization error - no call was made to `dvclive.init()` "
             " or `dvclive.log()` "
+        )
+
+
+class ConfigMismatchError(DvcLiveError):
+    def __init__(self, ml: "MetricLogger"):
+        from . import env
+
+        super().__init__(
+            f"Dvclive initialized in '{ml.dir}' conflicts "
+            f"with '{os.environ[env.DVCLIVE_PATH]}' provided by DVC."
         )

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -61,7 +61,7 @@ class MetricLogger:
             os.remove(self.html_path)
 
     @staticmethod
-    def from_env(existing_logger: "MetricLogger" = None):
+    def from_env():
         from . import env
 
         if env.DVCLIVE_PATH in os.environ:
@@ -74,31 +74,8 @@ class MetricLogger:
                 ),
                 "resume": bool(int(os.environ.get(env.DVCLIVE_RESUME, "0"))),
             }
-
-            if existing_logger:
-
-                def config_matches(metric_logger: MetricLogger):
-                    return (
-                        env_config["summary"] == metric_logger._summary
-                        and env_config["html"] == metric_logger._html
-                        and env_config["checkpoint"]
-                        == metric_logger._checkpoint
-                    )
-
-                if existing_logger.dir == directory and config_matches(
-                    existing_logger
-                ):
-                    return existing_logger
-                else:
-                    logger.info(
-                        "Dvclive logger config ('%s') has changed. "
-                        "New logger will write to '%s'.",
-                        existing_logger.dir,
-                        directory,
-                    )
-
             return MetricLogger(directory, **env_config)
-        return existing_logger
+        return None
 
     def matches_env_setup(self):
         from . import env

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -224,20 +224,6 @@ def test_fail_on_conflict(tmp_dir, monkeypatch):
         dvclive.log("m", 0.1)
 
 
-def test_dont_override_from_env(tmp_dir, monkeypatch):
-    dvclive.init("initial_path", summary=True, html=True)
-    dvclive.log("m", 0.1)
-
-    monkeypatch.setenv(env.DVCLIVE_PATH, "initial_path")
-    monkeypatch.setenv(env.DVCLIVE_SUMMARY, "1")
-    monkeypatch.setenv(env.DVCLIVE_HTML, "1")
-
-    dvclive.log("m", 0.2)
-    dvclive.log("m", 0.3)
-
-    assert read_history("initial_path", "m") == ([0, 1, 2], [0.1, 0.2, 0.3])
-
-
 @pytest.mark.parametrize("invalid_type", [{0: 1}, [0, 1], "foo", (0, 1)])
 def test_invalid_metric_type(tmp_dir, invalid_type):
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,10 +25,7 @@ def read_logs(path: str):
         metric_name = str(metric_file).replace(path + os.path.sep, "")
         metric_name = metric_name.replace(".tsv", "")
         history[metric_name] = _parse_tsv(metric_file)
-    try:
-        latest = _parse_json(path + ".json")
-    except FileNotFoundError:
-        latest = {}
+    latest = _parse_json(path + ".json")
     return history, latest
 
 


### PR DESCRIPTION
Fixes #60 

TODO
~~- [x] - allow overriding if proper env variable is present~~
~~- [x] - If same dir is provided via env, make sure to update config~~

EDIT:
we agreed in #74 to throw on configuration mismatch
