### PR TITLE
Safer cleanup

### DIFF
--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -52,7 +52,7 @@ class MetricLogger:
     def _cleanup(self):
 
         for dvclive_file in Path(self.dir).rglob("*.dvclive.tsv"):
-            dvclive_file.unlink(missing_ok=True)
+            dvclive_file.unlink()
 
         if os.path.exists(self.summary_path):
             os.remove(self.summary_path)

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -138,9 +138,7 @@ class MetricLogger:
         if step:
             self._step = step
 
-        metric_history_path = os.path.join(
-            self.history_path, name + ".tsv"
-        )
+        metric_history_path = os.path.join(self.history_path, name + ".tsv")
         os.makedirs(os.path.dirname(metric_history_path), exist_ok=True)
 
         nested_set(

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -139,7 +139,7 @@ class MetricLogger:
             self._step = step
 
         metric_history_path = os.path.join(
-            self.history_path, name + ".dvclive.tsv"
+            self.history_path, name + ".tsv"
         )
         os.makedirs(os.path.dirname(metric_history_path), exist_ok=True)
 

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import shutil
 import time
 from collections import OrderedDict
 from pathlib import Path
@@ -51,7 +50,7 @@ class MetricLogger:
                 ) from exception
 
     def _cleanup(self):
-        
+
         for dvclive_file in Path(self.dir).rglob("*.dvclive.tsv"):
             dvclive_file.unlink(missing_ok=True)
 
@@ -139,7 +138,9 @@ class MetricLogger:
         if step:
             self._step = step
 
-        metric_history_path = os.path.join(self.history_path, name + ".dvclive.tsv")
+        metric_history_path = os.path.join(
+            self.history_path, name + ".dvclive.tsv"
+        )
         os.makedirs(os.path.dirname(metric_history_path), exist_ok=True)
 
         nested_set(

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import time
 from collections import OrderedDict
+from pathlib import Path
 from typing import Dict, Union
 
 from .dvc import get_signal_file_path, make_checkpoint
@@ -41,19 +42,24 @@ class MetricLogger:
             else:
                 self._step = step
         else:
-            shutil.rmtree(self.dir, ignore_errors=True)
-
-            if os.path.exists(self.summary_path):
-                os.remove(self.summary_path)
-            if os.path.exists(self.html_path):
-                os.remove(self.html_path)
-
+            self._cleanup()
             try:
                 os.makedirs(self.dir, exist_ok=True)
             except Exception as exception:
                 raise DvcLiveError(
                     "dvc-live cannot create log dir - '{}'".format(self.dir),
                 ) from exception
+
+    def _cleanup(self):
+        
+        for dvclive_file in Path(self.dir).rglob("*.dvclive.tsv"):
+            dvclive_file.unlink(missing_ok=True)
+
+        if os.path.exists(self.summary_path):
+            os.remove(self.summary_path)
+
+        if os.path.exists(self.html_path):
+            os.remove(self.html_path)
 
     @staticmethod
     def from_env():
@@ -133,7 +139,7 @@ class MetricLogger:
         if step:
             self._step = step
 
-        metric_history_path = os.path.join(self.history_path, name + ".tsv")
+        metric_history_path = os.path.join(self.history_path, name + ".dvclive.tsv")
         os.makedirs(os.path.dirname(metric_history_path), exist_ok=True)
 
         nested_set(

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -51,7 +51,7 @@ class MetricLogger:
 
     def _cleanup(self):
 
-        for dvclive_file in Path(self.dir).rglob("*.dvclive.tsv"):
+        for dvclive_file in Path(self.dir).rglob("*.tsv"):
             dvclive_file.unlink()
 
         if os.path.exists(self.summary_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,20 +120,23 @@ def test_html(tmp_dir, dvc_repo, html, signal_exists):
     "summary,html",
     [(True, True), (True, False), (False, True), (False, False)],
 )
-def test_clean_up(tmp_dir, summary, html):
+def test_cleanup(tmp_dir, summary, html):
     dvclive.init("logs", summary=summary, html=html)
     dvclive.log("m1", 1)
     dvclive.next_step()
     if html:
         (tmp_dir / "logs.html").touch()
 
-    assert (tmp_dir / "logs" / "m1.tsv").is_file()
+    (tmp_dir / "logs" / "some_user_file.txt").touch()
+
+    assert (tmp_dir / "logs" / "m1.dvclive.tsv").is_file()
     assert (tmp_dir / "logs.json").is_file() == summary
     assert (tmp_dir / "logs.html").is_file() == html
 
     dvclive.init("logs")
 
-    assert not (tmp_dir / "logs" / "m1.tsv").is_file()
+    assert (tmp_dir / "logs" / "some_user_file.txt").is_file()
+    assert not (tmp_dir / "logs" / "m1.dvclive.tsv").is_file()
     assert not (tmp_dir / "logs.json").is_file()
     assert not (tmp_dir / "logs.html").is_file()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ def read_logs(path: str):
     history = {}
     for metric_file in Path(path).rglob("*.tsv"):
         metric_name = str(metric_file).replace(path + os.path.sep, "")
-        metric_name = metric_name.replace(".dvclive.tsv", "")
+        metric_name = metric_name.replace(".tsv", "")
         history[metric_name] = _parse_tsv(metric_file)
     latest = _parse_json(path + ".json")
     return history, latest
@@ -65,7 +65,7 @@ def test_logging(tmp_dir, summary):
     dvclive.log("m1", 1)
 
     assert (tmp_dir / "logs").is_dir()
-    assert (tmp_dir / "logs" / "m1.dvclive.tsv").is_file()
+    assert (tmp_dir / "logs" / "m1.tsv").is_file()
     assert not (tmp_dir / "logs.json").is_file()
 
     dvclive.next_step()
@@ -82,8 +82,8 @@ def test_nested_logging(tmp_dir):
     assert (tmp_dir / "logs").is_dir()
     assert (tmp_dir / "logs" / "train").is_dir()
     assert (tmp_dir / "logs" / "val" / "val_1").is_dir()
-    assert (tmp_dir / "logs" / "train" / "m1.dvclive.tsv").is_file()
-    assert (tmp_dir / "logs" / "val" / "val_1" / "m1.dvclive.tsv").is_file()
+    assert (tmp_dir / "logs" / "train" / "m1.tsv").is_file()
+    assert (tmp_dir / "logs" / "val" / "val_1" / "m1.tsv").is_file()
 
     dvclive.next_step()
 
@@ -129,14 +129,14 @@ def test_cleanup(tmp_dir, summary, html):
 
     (tmp_dir / "logs" / "some_user_file.txt").touch()
 
-    assert (tmp_dir / "logs" / "m1.dvclive.tsv").is_file()
+    assert (tmp_dir / "logs" / "m1.tsv").is_file()
     assert (tmp_dir / "logs.json").is_file() == summary
     assert (tmp_dir / "logs.html").is_file() == html
 
     dvclive.init("logs")
 
     assert (tmp_dir / "logs" / "some_user_file.txt").is_file()
-    assert not (tmp_dir / "logs" / "m1.dvclive.tsv").is_file()
+    assert not (tmp_dir / "logs" / "m1.tsv").is_file()
     assert not (tmp_dir / "logs.json").is_file()
     assert not (tmp_dir / "logs.html").is_file()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ def read_logs(path: str):
     history = {}
     for metric_file in Path(path).rglob("*.tsv"):
         metric_name = str(metric_file).replace(path + os.path.sep, "")
-        metric_name = metric_name.replace(".tsv", "")
+        metric_name = metric_name.replace(".dvclive.tsv", "")
         history[metric_name] = _parse_tsv(metric_file)
     latest = _parse_json(path + ".json")
     return history, latest
@@ -65,7 +65,7 @@ def test_logging(tmp_dir, summary):
     dvclive.log("m1", 1)
 
     assert (tmp_dir / "logs").is_dir()
-    assert (tmp_dir / "logs" / "m1.tsv").is_file()
+    assert (tmp_dir / "logs" / "m1.dvclive.tsv").is_file()
     assert not (tmp_dir / "logs.json").is_file()
 
     dvclive.next_step()
@@ -82,8 +82,8 @@ def test_nested_logging(tmp_dir):
     assert (tmp_dir / "logs").is_dir()
     assert (tmp_dir / "logs" / "train").is_dir()
     assert (tmp_dir / "logs" / "val" / "val_1").is_dir()
-    assert (tmp_dir / "logs" / "train" / "m1.tsv").is_file()
-    assert (tmp_dir / "logs" / "val" / "val_1" / "m1.tsv").is_file()
+    assert (tmp_dir / "logs" / "train" / "m1.dvclive.tsv").is_file()
+    assert (tmp_dir / "logs" / "val" / "val_1" / "m1.dvclive.tsv").is_file()
 
     dvclive.next_step()
 


### PR DESCRIPTION
Changes:

- Added `.dvclive.tsv` prefix to *metrics logs* files. Does not affect visualizations with `dvc plots` or the HTML report.
- Replaced `shutil.rmdir` with `rglob`+`unlink()` to prevent unintentional deletions of user files.

Closes #102 

- [X] P.R. to `dvc.org` https://github.com/iterative/dvc.org/pull/2653