### PR TITLE
Extend summary

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -230,7 +230,7 @@ def test_summary_last_max_min(tmp_dir):
 
     assert summary["last"]["step"] == 2
     assert summary["last"]["m"] == 0.15
-    
+
     assert summary["max"]["step"] == 2
     assert summary["max"]["m"] == 0.2
 


### PR DESCRIPTION
Closes #89 

This P.R. extends existing summary to have `last`, `max` and `min` sections.

Example:

```python
for value in [0.1, 0.2, 0.15]:
    dvclive.log("m", value)
    dvclive.next_step()
```

Currently generates:

```json
{
    "step": 2,
    "m": 0.15
}
```

After this P.R. would generate:

```json
{
    "last": {
        "m": 0.15,
        "step": 2
    },
    "max": {
        "m": 0.2,
        "step": 2
    },
    "min": {
        "m": 0.1,
        "step": 0
    }
}
```

It requires also changes in:

- [ ] P.R. to `dvc` 
- [ ] P.R. to `dvc.org`

Not sure how this kind of changes should be addressed on the `dvc` side (just breaks a few tests in `test_live`)  because it will require to have pinned versions of `dvclive` in C.I but tests that depend on `dvclive` are currently being skipped in `dvc` C.I.