### PR TITLE
build: tests: make tests run verbose

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install libomp
     - name: run tests
-      run: py.test --cov dvclive --cov-report=xml
+      run: py.test -v --cov dvclive --cov-report=xml
     - name: upload coverage report
       uses: codecov/codecov-action@v1.0.13
       with:


### PR DESCRIPTION
Add verbose option to the test build so that we can get more info on failed builds.