### PR TITLE
Add saving model in XGBoost

### DIFF
--- a/dvclive/xgb.py
+++ b/dvclive/xgb.py
@@ -4,13 +4,16 @@ import dvclive
 
 
 class DvcLiveCallback(TrainingCallback):
-    def __init__(self, metric_data):
+    def __init__(self, metric_data, model_file=None):
         super().__init__()
         self._metric_data = metric_data
+        self.model_file = model_file
 
     def after_iteration(self, model, epoch, evals_log):
         for key, values in evals_log[self._metric_data].items():
             if values:
                 latest_metric = values[-1]
             dvclive.log(key, latest_metric)
+        if self.model_file:
+            model.save_model(self.model_file)
         dvclive.next_step()

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+import numpy as np
 import pytest
 import xgboost as xgb
 from funcy import first
@@ -31,7 +32,7 @@ def test_xgb_integration(tmp_dir, train_params, iris_data):
     xgb.train(
         train_params,
         iris_data,
-        callbacks=[DvcLiveCallback("eval_data")],
+        callbacks=[DvcLiveCallback("eval_data", model_file="model_xgb.json")],
         num_boost_round=5,
         evals=[(iris_data, "eval_data")],
     )
@@ -41,3 +42,8 @@ def test_xgb_integration(tmp_dir, train_params, iris_data):
     logs, _ = read_logs("logs")
     assert len(logs) == 1
     assert len(first(logs.values())) == 5
+    
+    preds = xgb.predict(iris_data)
+    xgb2 = xgb.Booster(model_file="model_xgb.json")
+    preds2 = xgb2.predict(iris_data)
+    assert np.sum(np.abs(preds2 - preds)) == 0


### PR DESCRIPTION
Extend the existing XGBoost integration (dvc.xgb) to include model saving functionality. 

Closes #109 