### PR TITLE
Added `dvclive.get_step`

### DIFF
--- a/dvclive/__init__.py
+++ b/dvclive/__init__.py
@@ -10,14 +10,12 @@ _metric_logger: Optional[MetricLogger] = None
 def init(
     path: str = None,
     resume: bool = False,
-    step: int = 0,
     summary: bool = True,
 ) -> MetricLogger:
     global _metric_logger  # pylint: disable=global-statement
     _metric_logger = MetricLogger(
         path=path or MetricLogger.DEFAULT_DIR,
         resume=resume,
-        step=step,
         summary=summary,
     )
     return _metric_logger
@@ -37,6 +35,13 @@ def log(name: str, val: Union[int, float], step: int = None) -> None:
 
     _metric_logger.log(name=name, val=val, step=step)
 
+def get_step() -> None:
+    global _metric_logger  # pylint: disable=global-statement
+    if not _metric_logger:
+        from .error import InitializationError
+
+        raise InitializationError()
+    return _metric_logger.step
 
 def next_step() -> None:
     global _metric_logger  # pylint: disable=global-statement

--- a/dvclive/__init__.py
+++ b/dvclive/__init__.py
@@ -17,8 +17,7 @@ def init(
     return _metric_logger
 
 
-def log(name: str, val: Union[int, float], step: int = None) -> None:
-    global _metric_logger  # pylint: disable=global-statement
+def _lazy_init(_metric_logger):
     if _metric_logger:
         if not _metric_logger.matches_env_setup():
             from .error import ConfigMismatchError
@@ -28,16 +27,19 @@ def log(name: str, val: Union[int, float], step: int = None) -> None:
         _metric_logger = MetricLogger.from_env()
     if not _metric_logger:
         _metric_logger = MetricLogger()
+    
+    return _metric_logger
 
+
+def log(name: str, val: Union[int, float], step: int = None) -> None:
+    global _metric_logger  # pylint: disable=global-statement
+    _metric_logger = _lazy_init(_metric_logger)
     _metric_logger.log(name=name, val=val, step=step)
 
 
 def get_step() -> None:
     global _metric_logger  # pylint: disable=global-statement
-    if not _metric_logger:
-        from .error import InitializationError
-
-        raise InitializationError()
+    _metric_logger = _lazy_init(_metric_logger)
     return _metric_logger.step
 
 

--- a/dvclive/__init__.py
+++ b/dvclive/__init__.py
@@ -8,15 +8,11 @@ _metric_logger: Optional[MetricLogger] = None
 
 
 def init(
-    path: str = None,
-    resume: bool = False,
-    summary: bool = True,
+    path: str = None, resume: bool = False, summary: bool = True,
 ) -> MetricLogger:
     global _metric_logger  # pylint: disable=global-statement
     _metric_logger = MetricLogger(
-        path=path or MetricLogger.DEFAULT_DIR,
-        resume=resume,
-        summary=summary,
+        path=path or MetricLogger.DEFAULT_DIR, resume=resume, summary=summary,
     )
     return _metric_logger
 
@@ -35,6 +31,7 @@ def log(name: str, val: Union[int, float], step: int = None) -> None:
 
     _metric_logger.log(name=name, val=val, step=step)
 
+
 def get_step() -> None:
     global _metric_logger  # pylint: disable=global-statement
     if not _metric_logger:
@@ -42,6 +39,7 @@ def get_step() -> None:
 
         raise InitializationError()
     return _metric_logger.step
+
 
 def next_step() -> None:
     global _metric_logger  # pylint: disable=global-statement

--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -21,25 +21,22 @@ class MetricLogger:
         self,
         path: str = "dvclive",
         resume: bool = False,
-        step: int = 0,
         summary=True,
         html=True,
         checkpoint=False,
     ):
         self._path: str = path
-        self._step: int = step
+        self._step: int = 0
         self._html: bool = html
         self._summary = summary
         self._metrics: Dict[str, float] = OrderedDict()
         self._checkpoint: bool = checkpoint
 
         if resume and self.exists:
-            if step == 0:
-                self._step = self.read_step()
-                if self._step != 0:
-                    self._step += 1
-            else:
-                self._step = step
+            self._step = self.read_step()
+            if self._step != 0:
+                self._step += 1
+
         else:
             self._cleanup()
             os.makedirs(self.dir, exist_ok=True)
@@ -102,6 +99,10 @@ class MetricLogger:
     @property
     def html_path(self):
         return self.dir + ".html"
+
+    @property
+    def step(self):
+        return self._step
 
     def next_step(self):
         if self._summary:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,14 +252,12 @@ def test_invalid_metric_type(tmp_dir, invalid_type):
         dvclive.log("m", invalid_type)
 
 
-@pytest.mark.parametrize("cmd", [dvclive.next_step, dvclive.get_step])
-def test_initialization_error(tmp_dir, cmd):
+def test_initialization_error(tmp_dir):
     with pytest.raises(InitializationError):
-        cmd()
+        dvclive.next_step()
 
 
-def test_get_step(tmp_dir):
-    dvclive.init("logs")
+def test_get_step_init(tmp_dir):
     assert dvclive.get_step() == 0
 
 
@@ -287,3 +285,14 @@ def test_get_step_custom_steps(tmp_dir):
         dvclive.log("m", metric, step=step)
 
         assert dvclive.get_step() == step
+
+def test_get_step_control_flow(tmp_dir):
+    dvclive.init("logs")
+
+    while dvclive.get_step() < 10:
+        dvclive.log("i", dvclive.get_step())
+        dvclive.next_step()
+
+    steps, values = read_history("logs", "i")
+    assert steps == list(range(10))
+    assert values == [float(x) for x in range(10)]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -251,7 +251,7 @@ def test_invalid_metric_type(tmp_dir, invalid_type):
     ):
         dvclive.log("m", invalid_type)
 
-
-def test_initialization_error(tmp_dir):
+@pytest.mark.parametrize("cmd", [dvclive.next_step, dvclive.get_step])
+def test_initialization_error(tmp_dir, cmd):
     with pytest.raises(InitializationError):
-        dvclive.next_step()
+        cmd()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ from funcy import last
 
 import dvclive
 from dvclive import env
+from dvclive import dvc
 
 # pylint: disable=unused-argument
 from dvclive.dvc import SIGNAL_FILE
@@ -255,3 +256,33 @@ def test_invalid_metric_type(tmp_dir, invalid_type):
 def test_initialization_error(tmp_dir, cmd):
     with pytest.raises(InitializationError):
         cmd()
+
+
+def test_get_step(tmp_dir):
+    dvclive.init("logs")
+    assert dvclive.get_step() == 0
+
+
+def test_get_step_resume(tmp_dir):
+    dvclive.init("logs")
+
+    for metric in [0.9, 0.8]:
+        dvclive.log("metric", metric)
+        dvclive.next_step()
+
+    assert dvclive.get_step() == 2
+
+    dvclive.init("logs", resume=True)
+
+    assert dvclive.get_step() == 2
+
+def test_get_step_custom_steps(tmp_dir):
+    dvclive.init("logs")
+
+    steps = [0, 62, 1000]
+    metrics = [0.9, 0.8, 0.7]
+
+    for step, metric in zip(steps, metrics):
+        dvclive.log("m", metric, step=step)
+
+        assert dvclive.get_step() == step

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,6 @@ from funcy import last
 
 import dvclive
 from dvclive import env
-from dvclive import dvc
 
 # pylint: disable=unused-argument
 from dvclive.dvc import SIGNAL_FILE
@@ -252,6 +251,7 @@ def test_invalid_metric_type(tmp_dir, invalid_type):
     ):
         dvclive.log("m", invalid_type)
 
+
 @pytest.mark.parametrize("cmd", [dvclive.next_step, dvclive.get_step])
 def test_initialization_error(tmp_dir, cmd):
     with pytest.raises(InitializationError):
@@ -275,6 +275,7 @@ def test_get_step_resume(tmp_dir):
     dvclive.init("logs", resume=True)
 
     assert dvclive.get_step() == 2
+
 
 def test_get_step_custom_steps(tmp_dir):
     dvclive.init("logs")


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Closes #113 
Closes #128

This P.R. introduces a new public function: `dvclive.get_step()` and removes `step` from `dvclive.init()` 

The main use cases are driven by (but not limited to) using dvclive alongside `dvc checkpoints` and resuming training:

- Custom control flow

```python
while dvclive.get_step() < X:
    train()
    metrics = eval()
    for m, v in metrics.items():
        dvclive.log(m, v)
    dvclive.next_step()
```
- ML Framework

```python
model.fit(
    . . .
    epochs=params["epochs"],
    initial_epoch=dvclive.get_step(),
)
```
