### PR TITLE
Fixed infer `next_step` for nested metric

### DIFF
--- a/dvclive/metrics.py
+++ b/dvclive/metrics.py
@@ -124,7 +124,9 @@ class MetricLogger:
         if self._checkpoint:
             make_checkpoint()
 
-    def log(self, name: str, val: Union[int, float], step: Optional[int] = None):
+    def log(
+        self, name: str, val: Union[int, float], step: Optional[int] = None
+    ):
         splitted_name = os.path.normpath(name).split(os.path.sep)
         if nested_get(self._metrics, splitted_name) is not None:
             logger.info(

--- a/dvclive/utils.py
+++ b/dvclive/utils.py
@@ -14,6 +14,7 @@ def nested_set(d, keys, value):
         d = d.setdefault(key, {})
     d[keys[-1]] = value
 
+
 def nested_get(d, keys):
     """Get `value` in d[keys[0]]...[keys[-1]].
 

--- a/dvclive/utils.py
+++ b/dvclive/utils.py
@@ -13,3 +13,19 @@ def nested_set(d, keys, value):
     for key in keys[:-1]:
         d = d.setdefault(key, {})
     d[keys[-1]] = value
+
+def nested_get(d, keys):
+    """Get `value` in d[keys[0]]...[keys[-1]].
+
+    Example:
+    >>> d = {'person': {'address': {'city': 'New York'}}}
+    >>> nested_get(d, ['person', 'address', 'city'])
+    >>> d
+    'New York'
+    """
+    value = d
+    for key in keys:
+        if key not in value:
+            return None
+        value = value[key]
+    return value

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,7 +172,7 @@ def test_continue(tmp_dir, resume, steps, metrics):
     assert read_latest("logs", "metric") == (last(steps), last(metrics))
 
 
-@pytest.mark.parametrize("metric", ["m1", "train/m1"])
+@pytest.mark.parametrize("metric", ["m1", os.path.join("train", "m1")])
 def test_infer_next_step(tmp_dir, mocker, metric):
     dvclive.init("logs")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,15 +172,16 @@ def test_continue(tmp_dir, resume, steps, metrics):
     assert read_latest("logs", "metric") == (last(steps), last(metrics))
 
 
-def test_infer_next_step(tmp_dir, mocker):
+@pytest.mark.parametrize("metric", ["m1", "train/m1"])
+def test_infer_next_step(tmp_dir, mocker, metric):
     dvclive.init("logs")
 
     m = mocker.spy(dvclive.metrics.MetricLogger, "next_step")
-    dvclive.log("m1", 1.0)
-    dvclive.log("m1", 2.0)
-    dvclive.log("m1", 3.0)
+    dvclive.log(metric, 1.0)
+    dvclive.log(metric, 2.0)
+    dvclive.log(metric, 3.0)
 
-    assert read_history("logs", "m1") == ([0, 1, 2], [1.0, 2.0, 3.0])
+    assert read_history("logs", metric) == ([0, 1, 2], [1.0, 2.0, 3.0])
     assert m.call_count == 2
 
 


### PR DESCRIPTION
Subsequent calls of `dvclive.log()` using a nested metric name (i.e. `"train/foo"`) were not triggering `next_step`
