### PR TITLE
tests: catalyst: make session scope data source

### DIFF
--- a/tests/test_catalyst.py
+++ b/tests/test_catalyst.py
@@ -13,14 +13,11 @@ from dvclive.catalyst import DvcLiveCallback
 # pylint: disable=redefined-outer-name, unused-argument
 
 
-@pytest.fixture
-def loaders():
-    train_data = MNIST(
-        os.getcwd(), train=True, download=True, transform=ToTensor()
-    )
-    valid_data = MNIST(
-        os.getcwd(), train=False, download=True, transform=ToTensor()
-    )
+@pytest.fixture(scope="session")
+def loaders(tmp_path_factory):
+    path = tmp_path_factory.mktemp("catalyst_mnist")
+    train_data = MNIST(path, train=True, download=True, transform=ToTensor())
+    valid_data = MNIST(path, train=False, download=True, transform=ToTensor())
     return {
         "train": DataLoader(train_data, batch_size=32),
         "valid": DataLoader(valid_data, batch_size=32),


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Prevent catalyst from making MNIST dir in repo dir, make session-scoped dir that can be utilized by all tests.