### PR TITLE
lightning: Override all dataloader methods

### DIFF
--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -69,6 +69,15 @@ class LitMNIST(LightningModule):
     def configure_optimizers(self):
         return Adam(self.parameters(), lr=1e-3)
 
+    def predict_dataloader(self):
+        pass
+
+    def test_dataloader(self):
+        pass
+
+    def val_dataloader(self):
+        pass
+
 
 def test_lightning_integration(tmp_dir):
     # init model


### PR DESCRIPTION
Latest version (v1.5.0) requires to override all dataloader methods: PyTorchLightning/pytorch-lightning#9161 making pylint raise error in our test

Close #186