### PR TITLE
sklearn: Add basic logging methods.

### DIFF
--- a/dvclive/sklearn.py
+++ b/dvclive/sklearn.py
@@ -1,0 +1,83 @@
+import json
+import math
+
+import numpy as np
+from sklearn import metrics
+
+
+def _check_binary(y_true):
+    if len(np.unique(y_true)) > 2:
+        raise ValueError(
+            "Only binary classification is supported for roc_curve."
+        )
+
+
+def _dump(content, output_file):
+    with open(output_file, "w") as f:
+        json.dump(content, f, indent=4)
+
+
+def log_classification_report(y_true, y_pred, output_file, **kwargs):
+    kwargs["output_dict"] = True
+
+    classification_report = metrics.classification_report(
+        y_true=y_true, y_pred=y_pred, **kwargs
+    )
+
+    _dump(classification_report, output_file)
+
+    return classification_report
+
+
+def log_roc_curve(y_true, y_score, output_file, **kwargs):
+    _check_binary(y_true)
+
+    fpr, tpr, roc_thresholds = metrics.roc_curve(
+        y_true=y_true, y_score=y_score, **kwargs
+    )
+
+    roc = {
+        "roc": [
+            {"fpr": fp, "tpr": tp, "threshold": t}
+            for fp, tp, t in zip(fpr, tpr, roc_thresholds)
+        ]
+    }
+
+    _dump(roc, output_file)
+
+    return roc
+
+
+def log_precision_recall_curve(y_true, probas_pred, output_file, **kwargs):
+    _check_binary(y_true)
+
+    precision, recall, prc_thresholds = metrics.precision_recall_curve(
+        y_true=y_true, probas_pred=probas_pred, **kwargs
+    )
+
+    # ROC has a drop_intermediate arg that reduces the number of points.
+    # https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_curve.html#sklearn.metrics.roc_curve.
+    # PRC lacks this arg, so we manually reduce to 1000 as a rough estimate.
+    nth_point = math.ceil(len(prc_thresholds) / 1000)
+    prc_points = list(zip(precision, recall, prc_thresholds))[::nth_point]
+
+    prc = {
+        "prc": [
+            {"precision": p, "recall": r, "threshold": t}
+            for p, r, t in prc_points
+        ]
+    }
+    _dump(prc, output_file)
+
+    return prc
+
+
+def log_confusion_matrix(y_true, y_pred, output_file, **kwargs):
+    confusion_matrix_disp = metrics.ConfusionMatrixDisplay.from_predictions(
+        y_true=y_true, y_pred=y_pred, **kwargs
+    )
+
+    confusion_matrix_disp.plot()
+    confusion_matrix_disp.figure_.savefig(output_file)
+
+    return confusion_matrix_disp

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -182,7 +182,7 @@ def test_require_step_update(tmp_dir, metric):
         dvclive.log(metric, 2.0)
 
 
-def test_custom_steps(tmp_dir, mocker):
+def test_custom_steps(tmp_dir):
     dvclive = Live("logs")
 
     steps = [0, 62, 1000]

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1,0 +1,91 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dvclive.sklearn import (
+    log_classification_report,
+    log_confusion_matrix,
+    log_precision_recall_curve,
+    log_roc_curve,
+)
+
+# pylint: disable=redefined-outer-name, unused-argument
+
+
+@pytest.fixture
+def y_true_y_pred_y_score():
+    from sklearn.datasets import make_classification
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.model_selection import train_test_split
+
+    X, y = make_classification(random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    clf = RandomForestClassifier(random_state=0)
+    clf.fit(X_train, y_train)
+
+    y_pred = clf.predict(X_test)
+    y_score = clf.predict_proba(X_test)[:, 1]
+
+    return y_test, y_pred, y_score
+
+
+def test_log_classification_report(tmp_dir, y_true_y_pred_y_score, mocker):
+    from dvclive.sklearn import metrics
+
+    y_true, y_pred, _ = y_true_y_pred_y_score
+
+    spy = mocker.spy(metrics, "classification_report")
+
+    classification_report = log_classification_report(
+        y_true=y_true, y_pred=y_pred, output_file="classification_report.json"
+    )
+
+    spy.assert_called_once_with(y_true, y_pred, output_dict=True)
+
+    assert (
+        json.dumps(classification_report, indent=4)
+        == Path("classification_report.json").read_text()
+    )
+
+
+def test_log_roc_curve(tmp_dir, y_true_y_pred_y_score, mocker):
+    from dvclive.sklearn import metrics
+
+    y_true, _, y_score = y_true_y_pred_y_score
+
+    spy = mocker.spy(metrics, "roc_curve")
+
+    roc = log_roc_curve(y_true=y_true, y_score=y_score, output_file="roc.json")
+
+    spy.assert_called_once_with(y_true, y_score)
+
+    assert json.dumps(roc, indent=4) == Path("roc.json").read_text()
+
+
+def test_log_prc_curve(tmp_dir, y_true_y_pred_y_score, mocker):
+    from dvclive.sklearn import metrics
+
+    y_true, _, y_score = y_true_y_pred_y_score
+
+    spy = mocker.spy(metrics, "precision_recall_curve")
+
+    prc = log_precision_recall_curve(
+        y_true=y_true, probas_pred=y_score, output_file="prc.json"
+    )
+
+    spy.assert_called_once_with(y_true, y_score)
+
+    assert json.dumps(prc, indent=4) == Path("prc.json").read_text()
+
+
+def test_log_confusion_matrix(tmp_dir, y_true_y_pred_y_score, mocker):
+    y_true, y_pred, _ = y_true_y_pred_y_score
+
+    mocker.patch("sklearn.metrics.ConfusionMatrixDisplay.from_predictions")
+
+    mock = log_confusion_matrix(
+        y_true=y_true, y_pred=y_pred, output_file="confusion_matrix.png"
+    )
+
+    mock.figure_.savefig.assert_called_with("confusion_matrix.png")


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

---

Per https://github.com/iterative/dvclive/issues/5#issuecomment-953295791 added a few utilities:

- log_classification_report
- log_confusion_matrix
- log_precision_recall_curve
- log_roc_curve

---

Example:

<details>
<summary>foo.py</summary>

```python
from dvclive.sklearn import (
    log_classification_report,
    log_confusion_matrix,
    log_precision_recall_curve,
    log_roc_curve,
)

from sklearn.datasets import make_classification
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import train_test_split

X, y = make_classification(random_state=0)
X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
clf = RandomForestClassifier(random_state=0)
clf.fit(X_train, y_train)

y_pred = clf.predict(X_test)
y_score = clf.predict_proba(X_test)[:, 1]

classification_report = log_classification_report(y_test, y_pred, "classification_report.json")
cm = log_confusion_matrix(y_test, y_pred, "confusion_matrix.png")
prc = log_precision_recall_curve(y_test, y_score, "prc.json")
roc = log_roc_curve(y_test, y_score, "roc.json")
```

</details>

```yaml
stages:
  foo:
    cmd: python foo.py
    metrics:
      - classification_report.json
    plots:
    - confusion_matrix.png
    - prc.json:
        cache: false
        x: recall
        y: precision
        title: Precision Recall Curve
    - roc.json:
        cache: false
        x: fpr
        y: tpr
        title: ROC curve
```

`dvc exp show`

| Experiment   | Created   | 0.precision   | 0.recall   | 0.f1-score   | 0.support   | 1.precision   | 1.recall   | 1.f1-score   | 1.support   | accuracy   | macro avg.precision   | macro avg.recall   | macro avg.f1-score   | macro avg.support   | weighted avg.precision   | weighted avg.recall   | weighted avg.f1-score   | weighted avg.support   |
|--------------|-----------|---------------|------------|--------------|-------------|---------------|------------|--------------|-------------|------------|-----------------------|--------------------|----------------------|---------------------|--------------------------|-----------------------|-------------------------|------------------------|
| workspace    | -         | 0.92308       | 0.92308    | 0.92308      | 13          | 0.91667       | 0.91667    | 0.91667      | 12          | 0.92       | 0.91987               | 0.91987            | 0.91987              | 25                  | 0.92                     | 0.92                  | 0.92                    | 25                     |
| master       | 09:10 PM  | 0.92308       | 0.92308    | 0.92308      | 13          | 0.91667       | 0.91667    | 0.91667      | 12          | 0.92       | 0.91987               | 0.91987            | 0.91987              | 25                  | 0.92                     | 0.92                  | 0.92                    | 25                     |

`dvc plots show`

![Screenshot 2021-11-08 at 21-13-05 DVC Plot](https://user-images.githubusercontent.com/12677733/140811306-0d40411e-a51f-41d4-b0b2-103a30ffc09f.png)



