### PR TITLE
update metric summary data of arbitrary depth

### DIFF
--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 from collections import OrderedDict
-from collections.abs import Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 

--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -3,25 +3,15 @@ import logging
 import os
 import shutil
 from collections import OrderedDict
-from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from .data import DATA_TYPES
 from .dvc import make_checkpoint, make_html
+from .utils import nested_update
 from .error import ConfigMismatchError, InvalidDataTypeError
 
 logger = logging.getLogger(__name__)
-
-
-def update_nesteddict(d, u):
-    """Update values of a nested dictionnary of varying depth"""
-    for k, v in u.items():
-        if isinstance(v, Mapping):
-            d[k] = update_nesteddict(d.get(k, {}), v)
-        else:
-            d[k] = v
-    return d
 
 
 class Live:
@@ -154,7 +144,7 @@ class Live:
         summary_data = {"step": self.get_step()}
 
         for data in self._data.values():
-            summary_data = update_nesteddict(summary_data, data.summary)
+            summary_data = nested_update(summary_data, data.summary)
 
         with open(self.summary_path, "w") as f:
             json.dump(summary_data, f, indent=4)

--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, Optional, Union
 
 from .data import DATA_TYPES
 from .dvc import make_checkpoint, make_html
-from .utils import nested_update
 from .error import ConfigMismatchError, InvalidDataTypeError
+from .utils import nested_update
 
 logger = logging.getLogger(__name__)
 

--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 from collections import OrderedDict
+from collections.abs import Mapping
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -11,6 +12,16 @@ from .dvc import make_checkpoint, make_html
 from .error import ConfigMismatchError, InvalidDataTypeError
 
 logger = logging.getLogger(__name__)
+
+
+def update_nesteddict(d, u):
+    """Update values of a nested dictionnary of varying depth"""
+    for k, v in u.items():
+        if isinstance(v, Mapping):
+            d[k] = update_nesteddict(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
 
 
 class Live:
@@ -143,7 +154,7 @@ class Live:
         summary_data = {"step": self.get_step()}
 
         for data in self._data.values():
-            summary_data.update(data.summary)
+            summary_data = update_nesteddict(summary_data, data.summary)
 
         with open(self.summary_path, "w") as f:
             json.dump(summary_data, f, indent=4)

--- a/dvclive/utils.py
+++ b/dvclive/utils.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+
+
 def nested_set(d, keys, value):
     """Set d[keys[0]]...[keys[-1]] to `value`.
 
@@ -13,3 +16,13 @@ def nested_set(d, keys, value):
     for key in keys[:-1]:
         d = d.setdefault(key, {})
     d[keys[-1]] = value
+
+
+def nested_update(d, u):
+    """Update values of a nested dictionnary of varying depth"""
+    for k, v in u.items():
+        if isinstance(v, Mapping):
+            d[k] = nested_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,15 +81,18 @@ def test_nested_logging(tmp_dir):
 
     dvclive.log("train/m1", 1)
     dvclive.log("val/val_1/m1", 1)
+    dvclive.log("val/val_1/m2", 1)
 
     assert (tmp_dir / "logs" / "val" / "val_1").is_dir()
     assert (tmp_dir / "logs" / "train" / "m1.tsv").is_file()
     assert (tmp_dir / "logs" / "val" / "val_1" / "m1.tsv").is_file()
+    assert (tmp_dir / "logs" / "val" / "val_1" / "m2.tsv").is_file()
 
     _, summary = read_logs("logs")
 
     assert summary["train"]["m1"] == 1
     assert summary["val"]["val_1"]["m1"] == 1
+    assert summary["val"]["val_1"]["m2"] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The default `dict.update` method only update the 1st level key of the
dict. When using metric with with 2 or more nested levels, only the
last update of each nested key will be kept.
For example:

>> summary_data = {'valid': {'accuracy': 0.6}}
>> summary = {'valid': {'precision': 0.5}}
>> summary_data.update(summary)
>>> summary_data
{'valid': {'precision': 0.5}}

The function `update_nesteddict` will correctly update an arbitrarily
nested dict, so that:

>> summary_data = {'valid': {'accuracy': 0.6}}
>> summary = {'valid': {'precision': 0.5}}
>> summary_data = update_nesteddict(summary)
>>> summary_data
{'valid': {'precision': 0.5, 'accuracy': 0.6}}

Fixes #196 

* [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
