### PR TITLE
Add `patch_tensorboard`

### DIFF
--- a/dvclive/data/base.py
+++ b/dvclive/data/base.py
@@ -5,18 +5,34 @@ from typing import Optional
 from dvclive.error import DataAlreadyLoggedError
 
 
+def _is_np(val):
+    return val.__class__.__module__ == "numpy"
+
+
+def _is_tf(val):
+    return val.__class__.__module__.split(".")[0] == "tensorflow"
+
+
 class Data(abc.ABC):
     def __init__(self, name: str, output_folder: str) -> None:
         self.name = name
         self.output_folder: Path = Path(output_folder) / self.subfolder
         self._step: Optional[int] = None
-        self.val = None
+        self._val = None
         self._step_none_logged: bool = False
         self._dump_kwargs = None
 
     @property
     def step(self) -> int:
         return self._step
+
+    @property
+    def val(self):
+        return self._val
+
+    @val.setter
+    def val(self, x):
+        self._val = x
 
     @step.setter
     def step(self, val: int) -> None:

--- a/dvclive/data/scalar.py
+++ b/dvclive/data/scalar.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from dvclive.utils import nested_set
 
-from .base import Data
+from .base import Data, _is_tf
 
 
 class Scalar(Data):
@@ -17,7 +17,25 @@ class Scalar(Data):
     def could_log(val: object) -> bool:
         if isinstance(val, (int, float)):
             return True
+        if _is_tf(val):
+            return True
         return False
+
+    @property
+    def val(self):
+        return self._val
+
+    @val.setter
+    def val(self, x):
+        if _is_tf(x):
+            import numpy as np
+
+            x = x.numpy().squeeze()
+            if isinstance(x, np.integer):
+                x = int(x)
+            else:
+                x = float(x)
+        self._val = x
 
     @property
     def output_path(self) -> Path:

--- a/dvclive/tensorboard.py
+++ b/dvclive/tensorboard.py
@@ -1,0 +1,53 @@
+import gorilla
+import tensorflow as tf
+
+from dvclive import Live
+
+# pylint: disable=unused-argument, no-member
+
+
+def patch_tensorboard(override: bool = True, **kwargs):
+    live = Live(**kwargs)
+    settings = gorilla.Settings(allow_hit=True, store_hit=True)
+
+    original_scalar = gorilla.Patch(
+        tf.summary, "original_scalar", tf.summary.scalar, settings=settings
+    )
+    gorilla.apply(original_scalar)
+
+    def log_scalar(name, data, step=None, description=None):
+        if step is not None:
+            if step != live.get_step():
+                live.set_step(step)
+        live.log(name, data)
+        if not override:
+            tf.summary.original_scalar(name, data, step=None, description=None)
+
+    original_image = gorilla.Patch(
+        tf.summary, "original_image", tf.summary.image, settings=settings
+    )
+    gorilla.apply(original_image)
+
+    def log_image(name, data, step=None, max_outputs=3, description=None):
+        name += ".png"
+        if step is not None:
+            if step != live.get_step():
+                live.set_step(step)
+        if len(data) > 1:
+            for n, image in enumerate(data):
+                if n > max_outputs:
+                    break
+                live.log_image(f"sample-{n}-{name}", image)
+        else:
+            live.log_image(name, data[0])
+
+        if not override:
+            tf.summary.original_image(name, data, step=None, description=None)
+
+    scalar_patch = gorilla.Patch(tf.summary, "scalar", log_scalar, settings)
+    gorilla.apply(scalar_patch)
+
+    image_patch = gorilla.Patch(tf.summary, "image", log_image, settings)
+    gorilla.apply(image_patch)
+
+    return original_scalar, original_image, scalar_patch, image_patch

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,22 @@ hugginface = ["transformers", "datasets"]
 catalyst = ["catalyst<=21.12"]
 fastai = ["fastai"]
 pl = ["pytorch_lightning"]
+image = ["pillow"]
+tensorboard = tf + ["gorilla"]
 
-all_libs = mmcv + tf + xgb + lgbm + hugginface + catalyst + fastai + pl + plots
+all_libs = (
+    mmcv
+    + tf
+    + xgb
+    + lgbm
+    + hugginface
+    + catalyst
+    + fastai
+    + pl
+    + image
+    + plots
+    + tensorboard
+)
 
 tests_requires = [
     "pylint==2.5.3",
@@ -83,6 +97,7 @@ setup(
         "sklearn": plots,
         "image": image,
         "plots": plots,
+        "tensorboard": tensorboard,
     },
     keywords="data-science metrics machine-learning developer-tools ai",
     python_requires=">=3.6",

--- a/tests/test_data/test_image.py
+++ b/tests/test_data/test_image.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
+import tensorflow as tf
 from PIL import Image
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument,no-value-for-parameter
 from dvclive import Live
 from dvclive.data import Image as LiveImage
 
@@ -27,6 +28,14 @@ def test_numpy(tmp_dir, shape):
     dvclive = Live()
     img = np.ones(shape, np.uint8) * 255
     dvclive.log_image("image.png", img)
+
+    assert (tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png").exists()
+
+
+@pytest.mark.parametrize("shape", [(500, 500), (500, 500, 3), (500, 500, 4)])
+def test_tensorflow(tmp_dir, shape):
+    dvclive = Live()
+    dvclive.log_image("image.png", tf.zeros(shape=shape, dtype=tf.uint8))
 
     assert (tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png").exists()
 

--- a/tests/test_data/test_scalar.py
+++ b/tests/test_data/test_scalar.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+from dvclive import Live
+from tests.test_main import _parse_json
+
+# pylint: disable=unused-argument
+
+
+def test_tensorflow(tmp_dir):
+    dvclive = Live()
+    dvclive.log("int", tf.constant(1))
+    dvclive.log("float", tf.constant(1.5))
+
+    summary = _parse_json("dvclive.json")
+
+    assert isinstance(summary["int"], int)
+    assert summary["int"] == 1
+    assert isinstance(summary["float"], float)
+    assert summary["float"] == 1.5

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -1,0 +1,72 @@
+import os
+
+import gorilla
+import tensorflow as tf
+
+from dvclive.tensorboard import patch_tensorboard
+from tests.test_main import _parse_json
+
+# pylint: disable=unused-argument, no-value-for-parameter
+
+
+def test_patch_tensorboard(tmp_dir, mocker):
+    scalar = mocker.spy(tf.summary, "scalar")
+    image = mocker.spy(tf.summary, "image")
+
+    patches = patch_tensorboard()
+
+    tf.summary.scalar("m", 0.5)
+    tf.summary.image("image", [tf.zeros(shape=[8, 8, 1], dtype=tf.uint8)])
+
+    assert not scalar.call_count
+    assert not image.call_count
+
+    summary = _parse_json("dvclive.json")
+    image_path = os.path.join("dvclive", "images", "image.png")
+    assert summary["m"] == 0.5
+    assert os.path.exists(image_path)
+
+    for patch in patches:
+        gorilla.revert(patch)
+
+
+def test_patch_tensorboard_no_override(tmp_dir, mocker):
+    scalar = mocker.spy(tf.summary, "scalar")
+    image = mocker.spy(tf.summary, "image")
+
+    patches = patch_tensorboard(override=False)
+
+    tf.summary.scalar("m", 0.5)
+    tf.summary.image("image", [tf.zeros(shape=[8, 8, 1], dtype=tf.uint8)])
+
+    assert scalar.call_count
+    assert image.call_count
+
+    summary = _parse_json("dvclive.json")
+    image_path = os.path.join("dvclive", "images", "image.png")
+    assert summary["m"] == 0.5
+    assert os.path.exists(image_path)
+
+    for patch in patches:
+        gorilla.revert(patch)
+
+
+def test_patch_tensorboard_live_args(tmp_dir, mocker):
+    scalar = mocker.spy(tf.summary, "scalar")
+    image = mocker.spy(tf.summary, "image")
+
+    patches = patch_tensorboard(path="logs")
+
+    tf.summary.scalar("m", 0.5)
+    tf.summary.image("image", [tf.zeros(shape=[8, 8, 1], dtype=tf.uint8)])
+
+    assert not scalar.call_count
+    assert not image.call_count
+
+    summary = _parse_json("logs.json")
+    image_path = os.path.join("logs", "images", "image.png")
+    assert summary["m"] == 0.5
+    assert os.path.exists(image_path)
+
+    for patch in patches:
+        gorilla.revert(patch)


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

---

Add `patch_tensorboard` function.

It can override or extend existing tensorboard logging calls by redirecting those to `Live.log`/`Live.log_image` calls.

This allows to patch both raw tensorboard calls but also existing callbacks using tensorboard:

```python

```

```python
from dvclive.tensorboard import patch_tensorboard
 
patch_tensorboard()

. . .
model.fit(
    x,
    y,
    epochs=2,
    callbacks=[tf.keras.callbacks.TensorBoard()],
)
```

`patch_tensorboard(override=False)` would generate DVCLive outputs while preserving the original behavior.