### PR TITLE
catalyst: restrict version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ tf = ["tensorflow"]
 xgb = ["xgboost"]
 lgbm = ["lightgbm"]
 hugginface = ["transformers", "datasets"]
-catalyst = ["catalyst"]
+catalyst = ["catalyst<=21.12"]
 fastai = ["fastai"]
 pl = ["pytorch_lightning"]
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

For `catalyst==22.02` our builds fail, need to investigate that, restricting the version for now.
Temporary workaround for #219 