### PR TITLE
live: `html` report without DVC.

### DIFF
--- a/dvclive/data/plot.py
+++ b/dvclive/data/plot.py
@@ -46,8 +46,22 @@ class Plot(Data):
             "DVCLive plots can only be used in no-step mode."
         )
 
+    @staticmethod
+    def get_properties():
+        raise NotImplementedError
+
 
 class Roc(Plot):
+    @staticmethod
+    def get_properties():
+        return {
+            "x": "fpr",
+            "y": "tpr",
+            "title": "Receiver operating characteristic (ROC)",
+            "x_label": "False Positive Rate",
+            "y_label": "True Positive Rate",
+        }
+
     def no_step_dump(self) -> int:
         from sklearn import metrics
 
@@ -64,6 +78,16 @@ class Roc(Plot):
 
 
 class PrecisionRecall(Plot):
+    @staticmethod
+    def get_properties():
+        return {
+            "x": "recall",
+            "y": "precision",
+            "title": "Precision-Recall Curve",
+            "x_label": "Recall",
+            "y_label": "Precision",
+        }
+
     def no_step_dump(self) -> int:
         from sklearn import metrics
 
@@ -72,7 +96,7 @@ class PrecisionRecall(Plot):
         )
 
         prc = {
-            "prc": [
+            "precision_recall": [
                 {"precision": p, "recall": r, "threshold": t}
                 for p, r, t in zip(precision, recall, prc_thresholds)
             ]
@@ -81,6 +105,16 @@ class PrecisionRecall(Plot):
 
 
 class Det(Plot):
+    @staticmethod
+    def get_properties():
+        return {
+            "x": "fpr",
+            "y": "fnr",
+            "title": "Detection error tradeoff (DET)",
+            "x_label": "False Positive Rate",
+            "y_label": "False Negative Rate",
+        }
+
     def no_step_dump(self) -> int:
         from sklearn import metrics
 
@@ -98,6 +132,17 @@ class Det(Plot):
 
 
 class ConfusionMatrix(Plot):
+    @staticmethod
+    def get_properties():
+        return {
+            "template": "confusion",
+            "x": "actual",
+            "y": "predicted",
+            "title": "Confusion Matrix",
+            "x_label": "True Label",
+            "y_label": "Predicted Label",
+        }
+
     def no_step_dump(self) -> int:
         cm = [
             {"actual": str(actual), "predicted": str(predicted)}
@@ -107,6 +152,16 @@ class ConfusionMatrix(Plot):
 
 
 class Calibration(Plot):
+    @staticmethod
+    def get_properties():
+        return {
+            "x": "prob_pred",
+            "y": "prob_true",
+            "title": "Calibration Curve",
+            "x_label": "Mean Predicted Probability",
+            "y_label": "Fraction of Positives",
+        }
+
     def no_step_dump(self) -> int:
         from sklearn import calibration
 

--- a/dvclive/dvc.py
+++ b/dvclive/dvc.py
@@ -43,14 +43,6 @@ def get_signal_file_path(root=None):
     return os.path.join(tmp, SIGNAL_FILE)
 
 
-def make_html():
-    signal_file_path = get_signal_file_path()
-    if signal_file_path:
-        if not os.path.exists(signal_file_path):
-            with open(signal_file_path, "w"):
-                pass
-
-
 def make_checkpoint():
     import builtins
     from time import sleep

--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -191,9 +191,9 @@ class Live:
     def make_report(self):
         if self._report == "html":
             html_report(self.dir, self.summary_path, self.html_path)
-        if self._auto_open:
-            open_file_in_browser(self.html_path)
-            self._auto_open = False
+            if self._auto_open:
+                open_file_in_browser(self.html_path)
+                self._auto_open = False
 
     def read_step(self):
         if Path(self.summary_path).exists():

--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -15,7 +15,7 @@ from .error import (
     InvalidPlotTypeError,
 )
 from .report import html_report
-from .utils import nested_update
+from .utils import nested_update, open_file_in_browser
 
 logger = logging.getLogger(__name__)
 
@@ -28,12 +28,14 @@ class Live:
         path: Optional[str] = None,
         resume: bool = False,
         report: Optional[str] = "html",
+        auto_open: bool = True,
     ):
 
         self._path: Optional[str] = path
         self._resume: bool = resume
         self._report: str = report
         self._checkpoint: bool = False
+        self._auto_open: bool = auto_open
 
         self.init_from_env()
 
@@ -189,6 +191,9 @@ class Live:
     def make_report(self):
         if self._report == "html":
             html_report(self.dir, self.summary_path, self.html_path)
+        if self._auto_open:
+            open_file_in_browser(self.html_path)
+            self._auto_open = False
 
     def read_step(self):
         if Path(self.summary_path).exists():

--- a/dvclive/report.py
+++ b/dvclive/report.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+from dvc_render.html import render_html
+from dvc_render.image import ImageRenderer
+from dvc_render.vega import VegaRenderer
+
+from dvclive.data import PLOTS, Image, Scalar
+from dvclive.data.plot import Plot
+from dvclive.utils import parse_tsv, to_base64_url
+
+
+def get_scalar_renderers(scalars_folder):
+    renderers = []
+    for suffix in Scalar.suffixes:
+        for file in Path(scalars_folder).rglob(f"*{suffix}"):
+            data = parse_tsv(file)
+            for row in data:
+                row["rev"] = "workspace"
+            rel = file.relative_to(scalars_folder).with_suffix("")
+            name = str(rel.as_posix())
+            properties = {"x": "step", "y": name}
+            renderers.append(VegaRenderer(data, name, **properties))
+    return renderers
+
+
+def get_image_renderers(images_folder):
+    renderers = []
+    for suffix in Image.suffixes:
+        for file in Path(images_folder).rglob(f"*{suffix}"):
+            name = str(file.relative_to(images_folder))
+            data = [
+                {
+                    ImageRenderer.SRC_FIELD: to_base64_url(file),
+                    ImageRenderer.TITLE_FIELD: name,
+                }
+            ]
+            renderers.append(ImageRenderer(data, name))
+    return renderers
+
+
+def get_plot_renderers(plots_folder):
+    renderers = []
+    for suffix in Plot.suffixes:
+        for file in Path(plots_folder).rglob(f"*{suffix}"):
+            name = file.stem
+            data = json.loads(file.read_text())
+            if name in data:
+                data = data[name]
+            for row in data:
+                row["rev"] = "workspace"
+            properties = PLOTS[name].get_properties()
+            renderers.append(VegaRenderer(data, name, **properties))
+    return renderers
+
+
+def get_metrics(dvclive_summary):
+    summary_path = Path(dvclive_summary)
+    if summary_path.exists():
+        return {
+            "": {
+                "data": {
+                    summary_path.name: {
+                        "data": json.loads(summary_path.read_text())
+                    }
+                }
+            }
+        }
+    return {}
+
+
+def html_report(dvclive_folder, dvclive_summary, output_html_path):
+    dvclive_path = Path(dvclive_folder)
+    renderers = []
+    renderers.extend(get_scalar_renderers(dvclive_path / Scalar.subfolder))
+    renderers.extend(get_image_renderers(dvclive_path / Image.subfolder))
+    renderers.extend(get_plot_renderers(dvclive_path / Plot.subfolder))
+
+    metrics = get_metrics(dvclive_summary)
+    render_html(
+        renderers, output_html_path, metrics=metrics, refresh_seconds=5
+    )

--- a/dvclive/utils.py
+++ b/dvclive/utils.py
@@ -1,4 +1,7 @@
+import base64
+import csv
 from collections.abc import Mapping
+from pathlib import Path
 
 
 def nested_set(d, keys, value):
@@ -26,3 +29,15 @@ def nested_update(d, u):
         else:
             d[k] = v
     return d
+
+
+def parse_tsv(path):
+    with open(path, "r") as fd:
+        reader = csv.DictReader(fd, delimiter="\t")
+        return list(reader)
+
+
+def to_base64_url(image_file):
+    image_bytes = Path(image_file).read_bytes()
+    base64_str = base64.b64encode(image_bytes).decode()
+    return f"data:image;base64,{base64_str}"

--- a/dvclive/utils.py
+++ b/dvclive/utils.py
@@ -1,7 +1,9 @@
 import base64
 import csv
+import webbrowser
 from collections.abc import Mapping
 from pathlib import Path
+from platform import uname
 
 
 def nested_set(d, keys, value):
@@ -41,3 +43,10 @@ def to_base64_url(image_file):
     image_bytes = Path(image_file).read_bytes()
     base64_str = base64.b64encode(image_bytes).decode()
     return f"data:image;base64,{base64_str}"
+
+
+def open_file_in_browser(file) -> bool:
+    path = Path(file)
+    url = path if "Microsoft" in uname().release else path.resolve().as_uri()
+
+    return webbrowser.open(url)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ class build_py(_build_py):
         _build_py.run(self)
 
 
+render = ["dvc_render"]
 image = ["pillow"]
 plots = ["scikit-learn"]
 mmcv = ["mmcv"]
@@ -47,7 +48,19 @@ catalyst = ["catalyst<=21.12"]
 fastai = ["fastai"]
 pl = ["pytorch_lightning<1.6"]
 
-all_libs = mmcv + tf + xgb + lgbm + hugginface + catalyst + fastai + pl + plots
+all_libs = (
+    render
+    + image
+    + mmcv
+    + tf
+    + xgb
+    + lgbm
+    + hugginface
+    + catalyst
+    + fastai
+    + pl
+    + plots
+)
 
 tests_requires = [
     "pylint==2.5.3",
@@ -69,6 +82,7 @@ setup(
     packages=find_packages(exclude="tests"),
     description="Metric logger for ML projects.",
     long_description=open("README.rst", "r", encoding="UTF-8").read(),
+    install_requires=render,
     extras_require={
         "tests": tests_requires,
         "all": all_libs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,8 @@ def capture_wrap():
     sys.stderr.close = lambda *args: None
     sys.stdout.close = lambda *args: None
     yield
+
+
+@pytest.fixture(autouse=True)
+def mocked_webbrowser_open(mocker):
+    mocker.patch("webbrowser.open")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,58 @@
+# pylint: disable=unused-argument
+import os
+
+from PIL import Image
+
+from dvclive import Live
+from dvclive.data import Image as LiveImage
+from dvclive.data import Scalar
+from dvclive.data.plot import ConfusionMatrix, Plot
+from dvclive.report import (
+    get_image_renderers,
+    get_plot_renderers,
+    get_scalar_renderers,
+)
+
+
+def test_get_renderers(tmp_dir, mocker):
+    live = Live()
+
+    for i in range(2):
+        live.log("foo", i)
+        img = Image.new("RGB", (10, 10), (i, i, i))
+        live.log_image("image.png", img)
+        live.next_step()
+
+    live.set_step(None)
+    live.log_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])
+
+    image_renderers = get_image_renderers(
+        tmp_dir / live.dir / LiveImage.subfolder
+    )
+    assert len(image_renderers) == 2
+    image_renderers = sorted(
+        image_renderers, key=lambda x: x.datapoints[0]["rev"]
+    )
+    for n, renderer in enumerate(image_renderers):
+        assert renderer.datapoints == [
+            {"src": mocker.ANY, "rev": os.path.join(str(n), "image.png")}
+        ]
+
+    scalar_renderers = get_scalar_renderers(
+        tmp_dir / live.dir / Scalar.subfolder
+    )
+    assert len(scalar_renderers) == 1
+    assert scalar_renderers[0].datapoints == [
+        {"foo": "0", "rev": "workspace", "step": "0", "timestamp": mocker.ANY},
+        {"foo": "1", "rev": "workspace", "step": "1", "timestamp": mocker.ANY},
+    ]
+
+    plot_renderers = get_plot_renderers(tmp_dir / live.dir / Plot.subfolder)
+    assert len(plot_renderers) == 1
+    assert plot_renderers[0].datapoints == [
+        {"actual": "0", "rev": "workspace", "predicted": "1"},
+        {"actual": "0", "rev": "workspace", "predicted": "0"},
+        {"actual": "1", "rev": "workspace", "predicted": "0"},
+        {"actual": "1", "rev": "workspace", "predicted": "1"},
+    ]
+    assert plot_renderers[0].properties == ConfusionMatrix.get_properties()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -73,3 +73,10 @@ def test_make_report_open(tmp_dir, mocker):
     live.make_report()
 
     assert not mocked_open.called
+
+    mocked_open = mocker.patch("webbrowser.open")
+    live = Live(report=None)
+    live.log("foo", 1)
+    live.next_step()
+
+    assert not mocked_open.called

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -56,3 +56,20 @@ def test_get_renderers(tmp_dir, mocker):
         {"actual": "1", "rev": "workspace", "predicted": "1"},
     ]
     assert plot_renderers[0].properties == ConfusionMatrix.get_properties()
+
+
+def test_make_report_open(tmp_dir, mocker):
+    mocked_open = mocker.patch("webbrowser.open")
+    live = Live()
+    live.log_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])
+    live.make_report()
+    live.make_report()
+
+    mocked_open.assert_called_once()
+
+    mocked_open = mocker.patch("webbrowser.open")
+    live = Live(auto_open=False)
+    live.log_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])
+    live.make_report()
+
+    assert not mocked_open.called


### PR DESCRIPTION
- Uses `dvc_render`.
- Add new method `Live.make_report` that users can call from a `Live` instance at any point. 

  This method is still called by default on `next_step` if the report has been enabled. I'm not sure about preserving that behavior and would move towards explicit `make_report` calls.
  
- Add new entry point `dvclive-show` that can generate the latest HTML report.

Defaults to the previous behavior, for now. `html` report only gets generated if enabled on the `dvc.yaml` side . However, users can manually enable `html` without DVC by passing:

```python
live = Live(report="html")
```

Closes #213 #195
