### PR TITLE
Removes noisy and misleading `print()` in init

### DIFF
--- a/dvclive/live.py
+++ b/dvclive/live.py
@@ -44,10 +44,6 @@ class Live:
         if self.html_path is None:
             self.html_path = os.path.join(self.dir, "report.html")
 
-        if self._report is not None:
-            out = Path(self.html_path).resolve()
-            print(f"Report will be saved at {out}")
-
         self._step: Optional[int] = None
         self._scalars: Dict[str, Any] = OrderedDict()
         self._images: Dict[str, Any] = OrderedDict()


### PR DESCRIPTION
- It's not very expected from a lib to have log messages, especially using `prints`
- `Report will be saved at` is printed in some cases but actual report is not created (e.g. if we use dvclive only as a tool to write plots, metrics, images)

----------------

* [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
