### PR TITLE
report: Introduce `markdown` support.

### DIFF
--- a/dvclive/report.py
+++ b/dvclive/report.py
@@ -3,12 +3,13 @@ from pathlib import Path
 
 from dvc_render.html import render_html
 from dvc_render.image import ImageRenderer
+from dvc_render.markdown import render_markdown
 from dvc_render.table import TableRenderer
 from dvc_render.vega import VegaRenderer
 
 from dvclive.data import PLOTS, Image, Scalar
 from dvclive.data.plot import Plot
-from dvclive.utils import parse_tsv, to_base64_url
+from dvclive.utils import parse_tsv
 
 
 def get_scalar_renderers(scalars_folder):
@@ -18,21 +19,30 @@ def get_scalar_renderers(scalars_folder):
             data = parse_tsv(file)
             for row in data:
                 row["rev"] = "workspace"
-            rel = file.relative_to(scalars_folder).with_suffix("")
-            name = str(rel.as_posix())
-            properties = {"x": "step", "y": name}
+
+            y = file.relative_to(scalars_folder).with_suffix("")
+            y = y.as_posix()
+
+            name = file.relative_to(scalars_folder.parent).with_suffix("")
+            name = name.as_posix()
+            name = name.replace(scalars_folder.name, "static")
+
+            properties = {"x": "step", "y": y}
             renderers.append(VegaRenderer(data, name, **properties))
     return renderers
 
 
 def get_image_renderers(images_folder):
+    dvclive_path = images_folder.parent
     renderers = []
     for suffix in Image.suffixes:
-        for file in Path(images_folder).rglob(f"*{suffix}"):
+        all_images = Path(images_folder).rglob(f"*{suffix}")
+        for file in sorted(all_images):
+            src = str(file.relative_to(dvclive_path))
             name = str(file.relative_to(images_folder))
             data = [
                 {
-                    ImageRenderer.SRC_FIELD: to_base64_url(file),
+                    ImageRenderer.SRC_FIELD: src,
                     ImageRenderer.TITLE_FIELD: name,
                 }
             ]
@@ -66,12 +76,19 @@ def get_metrics_renderers(dvclive_summary):
     return []
 
 
-def html_report(dvclive_folder, dvclive_summary, output_html_path):
+def make_report(dvclive_folder, dvclive_summary, output_path, mode):
     dvclive_path = Path(dvclive_folder)
+
     renderers = []
+    renderers.extend(get_metrics_renderers(dvclive_summary))
     renderers.extend(get_scalar_renderers(dvclive_path / Scalar.subfolder))
     renderers.extend(get_image_renderers(dvclive_path / Image.subfolder))
     renderers.extend(get_plot_renderers(dvclive_path / Plot.subfolder))
     renderers.extend(get_metrics_renderers(dvclive_summary))
 
-    render_html(renderers, output_html_path, refresh_seconds=5)
+    if mode == "html":
+        render_html(renderers, output_path, refresh_seconds=5)
+    elif mode == "md":
+        render_markdown(renderers, output_path)
+    else:
+        raise ValueError(f"Invalid `mode` {mode}.")

--- a/dvclive/utils.py
+++ b/dvclive/utils.py
@@ -1,4 +1,3 @@
-import base64
 import csv
 import os
 import re
@@ -39,12 +38,6 @@ def parse_tsv(path):
     with open(path, "r") as fd:
         reader = csv.DictReader(fd, delimiter="\t")
         return list(reader)
-
-
-def to_base64_url(image_file):
-    image_bytes = Path(image_file).read_bytes()
-    base64_str = base64.b64encode(image_bytes).decode()
-    return f"data:image;base64,{base64_str}"
 
 
 def run_once(f):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,8 @@ def capture_wrap():
 @pytest.fixture(autouse=True)
 def mocked_webbrowser_open(mocker):
     mocker.patch("webbrowser.open")
+
+
+@pytest.fixture(autouse=True)
+def mocked_CI(monkeypatch):
+    monkeypatch.setenv("CI", "false")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,7 +108,7 @@ def test_cleanup(tmp_dir, html):
     dvclive.log("m1", 1)
     dvclive.next_step()
 
-    html_path = tmp_dir / dvclive.html_path
+    html_path = tmp_dir / dvclive.report_path
     if html:
         html_path.touch()
 
@@ -222,10 +222,10 @@ def test_init_from_env(tmp_dir, html, monkeypatch):
     if html:
         html_path = str(dvclive.dir) + "_dvc_plots/index.html"
         assert dvclive._report == "html"
-        assert dvclive.html_path == html_path
+        assert dvclive.report_path == html_path
     else:
         assert dvclive._report is None
-        assert dvclive.html_path == os.path.join(dvclive.dir, "report.html")
+        assert dvclive.report_path == ""
 
 
 def test_fail_on_conflict(tmp_dir, monkeypatch):


### PR DESCRIPTION
Depends on https://github.com/iterative/dvc-render/pull/69
Closes #91 

The new default value for `report` is `auto`. 
If `CI` env var is set, use `md` else use `html`.

```python
import random
import time

from dvclive import Live
from PIL import Image
from PIL import ImageDraw 

live = Live(report="md")

for i in range(2):
    live.log("foo", i + random.random())
    live.log("bar", i + random.random())

    img = Image.new("RGB", (50, 50), (255, 255, 255))
    draw = ImageDraw.Draw(img)
    draw.text((20, 20), f"{i  + random.random():.1f}", (0,0,0))
    live.log_image("img.png", img)
    live.next_step()
    time.sleep(5)
```