### PR TITLE
[skip ci]: use pypa/gh-action-pypi-publish@release/v1

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,7 +21,6 @@ jobs:
       run: ./scripts/build_package.sh
     - name: Publish packages to PyPI
       if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-.

> The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or a full Git commit SHA.

Also drops `__token__`, which does not need to be specified as it's the default.