### PR TITLE
update lightning logger

### DIFF
--- a/dvclive/lightning.py
+++ b/dvclive/lightning.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 
-from pytorch_lightning.loggers import LightningLoggerBase
-from pytorch_lightning.loggers.base import rank_zero_experiment
+from pytorch_lightning.loggers.logger import Logger
+from pytorch_lightning.loggers.logger import rank_zero_experiment
 from pytorch_lightning.utilities import rank_zero_only
 from torch import is_tensor
 
@@ -9,7 +9,7 @@ from dvclive import Live
 from dvclive.utils import standardize_metric_name
 
 
-class DvcLiveLogger(LightningLoggerBase):
+class DvcLiveLogger(Logger):
     def __init__(
         self,
         run_name: Optional[str] = "dvclive_run",

--- a/dvclive/lightning.py
+++ b/dvclive/lightning.py
@@ -1,7 +1,6 @@
 from typing import Dict, Optional
 
-from pytorch_lightning.loggers.logger import Logger
-from pytorch_lightning.loggers.logger import rank_zero_experiment
+from pytorch_lightning.loggers.logger import Logger, rank_zero_experiment
 from pytorch_lightning.utilities import rank_zero_only
 from torch import is_tensor
 


### PR DESCRIPTION
To reproduce DeprecationWarning, run

```python
from logger import DvcLiveLogger
from pytorch_lightning import Trainer

import dvclive
import pytorch_lightning as pl
logger = DvcLiveLogger(
    path='./logs'
)

trainer = Trainer(
    logger=logger,
    accelerator='gpu'
)
print(dvclive.__version__)
print(pl.__version__)
```
This fixes warnings

* [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
