### PR TITLE
add log_param/log_params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ addopts = "-ra"
 
 [tool.coverage.run]
 branch = true
-source = ["dvclive", "tests"]
+source = ["src/dvclive", "tests"]
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ package_dir=
 packages = find:
 install_requires=
     dvc_render[table]>=0.0.8
+    ruamel.yaml>=0.17.11
 
 [options.extras_require]
 tests =

--- a/src/dvclive/error.py
+++ b/src/dvclive/error.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from .live import Live
@@ -44,3 +44,27 @@ class DataAlreadyLoggedError(DvcLiveError):
         super().__init__(
             f"Data '{name}' has already been logged with step '{step}'"
         )
+
+
+class ParameterAlreadyLoggedError(DvcLiveError):
+    def __init__(
+        self, name: str, val: Any, previous_val: Optional[Any] = None
+    ):
+        self.name = name
+        self.val = val
+        self.previous_val = previous_val
+        super().__init__(
+            f"Parameter '{name}={val}' has already been logged"
+            + (
+                f" (previous value={self.previous_val})."
+                if self.previous_val is not None
+                and self.val != self.previous_val
+                else "."
+            )
+        )
+
+
+class InvalidParameterTypeError(DvcLiveError):
+    def __init__(self, val: Any):
+        self.val = val
+        super().__init__(f"Parameter type {type(val)} is not supported.")

--- a/src/dvclive/serialize.py
+++ b/src/dvclive/serialize.py
@@ -1,0 +1,42 @@
+from collections import OrderedDict
+
+from dvclive.error import DvcLiveError
+
+
+class YAMLError(DvcLiveError):
+    pass
+
+
+class YAMLFileCorruptedError(YAMLError):
+    def __init__(self, path):
+        super().__init__(path, "YAML file structure is corrupted")
+
+
+def load_yaml(path, typ="safe"):
+    from ruamel.yaml import YAML
+    from ruamel.yaml import YAMLError as _YAMLError
+
+    yaml = YAML(typ=typ)
+    with open(path, encoding="utf-8") as fd:
+        try:
+            return yaml.load(fd.read())
+        except _YAMLError:
+            raise YAMLFileCorruptedError(path)
+
+
+def _get_yaml():
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    # tell Dumper to represent OrderedDict as normal dict
+    yaml_repr_cls = yaml.Representer
+    yaml_repr_cls.add_representer(OrderedDict, yaml_repr_cls.represent_dict)
+    return yaml
+
+
+def dump_yaml(path, data):
+    yaml = _get_yaml()
+    with open(path, "w", encoding="utf-8") as fd:
+        yaml.dump(data, fd)


### PR DESCRIPTION
Provides two new methods which log parameters to a yaml file (`params.yaml`):

- `log_param(name, value)` logs the given parameter name/value
- `log_params(params)` logs the given set of parameters (dict).