### PR TITLE
keras: add ability to pass live into callback

### DIFF
--- a/src/dvclive/keras.py
+++ b/src/dvclive/keras.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from tensorflow.keras.callbacks import (  # noqa pylint: disable=import-error, no-name-in-module
     Callback,
@@ -13,12 +14,16 @@ from dvclive.utils import standardize_metric_name
 
 class DvcLiveCallback(Callback):
     def __init__(
-        self, model_file=None, save_weights_only: bool = False, **kwargs
+        self,
+        model_file=None,
+        save_weights_only: bool = False,
+        dvclive: Optional[Live] = None,
+        **kwargs
     ):
         super().__init__()
         self.model_file = model_file
         self.save_weights_only = save_weights_only
-        self.dvclive = Live(**kwargs)
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
         if (

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from dvclive import Live
 from dvclive.data.scalar import Scalar
 from dvclive.keras import DvcLiveCallback
 from tests.test_main import read_logs
@@ -48,6 +49,26 @@ def test_keras_callback(tmp_dir, xor_model, capture_wrap):
 
     assert os.path.exists("dvclive")
     logs, _ = read_logs(tmp_dir / "dvclive" / Scalar.subfolder)
+
+    assert os.path.join("train", "accuracy") in logs
+    assert os.path.join("eval", "accuracy") in logs
+
+
+def test_keras_callback_pass_logger(tmp_dir, xor_model, capture_wrap):
+    model, x, y = xor_model()
+
+    logger = Live("train_logs")
+
+    model.fit(
+        x,
+        y,
+        epochs=1,
+        batch_size=1,
+        validation_split=0.2,
+        callbacks=[DvcLiveCallback(dvclive=logger)],
+    )
+    assert os.path.exists("train_logs")
+    logs, _ = read_logs(tmp_dir / "train_logs" / Scalar.subfolder)
 
     assert os.path.join("train", "accuracy") in logs
     assert os.path.join("eval", "accuracy") in logs


### PR DESCRIPTION
Suggestion. If we decide it's good I can try to add it to all other integrations.

It makes this workflow (non obvious, not natural, less scalable, and not documented?): 

```python
logger = DvcLiveCallback(path="evaluation", report=None)
live = logger.dvclive
```

into:

```python
live = Live("evaluation", report=None)

# ... somewhere down the road:

.... DvcLiveCallback(dvclive = live)
```

- We need an ability to pass live logger instance or params, otherwise callback would initialize its own instance and will be producing reports for example, would ignore path, etc, etc
- It's better to pass live to callbacks (vs asking callback to give us logger): proper order of control (code looks natural, easier to test), one `live` instance could be shared across multiple callbacks, etc
