### PR TITLE
cleanup log param

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -5,7 +5,7 @@ import shutil
 from collections import OrderedDict
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from ruamel.yaml.representer import RepresenterError
 
@@ -31,7 +31,7 @@ logger.setLevel(os.getenv(env.DVCLIVE_LOGLEVEL, "INFO").upper())
 # Recursive type aliases are not yet supported by mypy (as of 0.971),
 # so we set type: ignore for ParamLike.
 #  See https://github.com/python/mypy/issues/731#issuecomment-1213482527
-ParamLike = Union[int, float, str, bool, Dict[str, "ParamLike"]]  # type: ignore # noqa
+ParamLike = Union[int, float, str, bool, List["ParamLike"], Dict[str, "ParamLike"]]  # type: ignore # noqa
 
 
 class Live:

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -65,8 +65,6 @@ class Live:
         if self._path is None:
             self._path = self.DEFAULT_DIR
 
-        self._params_path = os.path.join(self._path, "params.yaml")
-
         if self._report is not None:
             if not self.report_path:
                 self.report_path = os.path.join(self.dir, f"report.{report}")
@@ -133,7 +131,7 @@ class Live:
 
     @property
     def params_path(self):
-        return self._params_path
+        return os.path.join(self.dir, "params.yaml")
 
     @property
     def exists(self):


### PR DESCRIPTION
- live: get rid of \_params_path
- live: update ParamLike to include lists
