### PR TITLE
Add ability to pass logger instance to frameworks

### DIFF
--- a/src/dvclive/catalyst.py
+++ b/src/dvclive/catalyst.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from catalyst import utils
 from catalyst.core.callback import Callback, CallbackOrder
 
@@ -5,10 +7,12 @@ from dvclive import Live
 
 
 class DvcLiveCallback(Callback):
-    def __init__(self, model_file=None, **kwargs):
+    def __init__(
+        self, model_file=None, dvclive: Optional[Live] = None, **kwargs
+    ):
         super().__init__(order=CallbackOrder.external)
-        self.dvclive = Live(**kwargs)
         self.model_file = model_file
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     def on_epoch_end(self, runner) -> None:
         for loader_key, per_loader_metrics in runner.epoch_metrics.items():

--- a/src/dvclive/fastai.py
+++ b/src/dvclive/fastai.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastai.callback.core import Callback
 
 from dvclive import Live
@@ -5,10 +7,12 @@ from dvclive.utils import standardize_metric_name
 
 
 class DvcLiveCallback(Callback):
-    def __init__(self, model_file=None, **kwargs):
+    def __init__(
+        self, model_file=None, dvclive: Optional[Live] = None, **kwargs
+    ):
         super().__init__()
         self.model_file = model_file
-        self.dvclive = Live(**kwargs)
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     def after_epoch(self):
         for key, value in zip(

--- a/src/dvclive/huggingface.py
+++ b/src/dvclive/huggingface.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from transformers import (
     TrainerCallback,
     TrainerControl,
@@ -10,10 +12,12 @@ from dvclive.utils import standardize_metric_name
 
 
 class DvcLiveCallback(TrainerCallback):
-    def __init__(self, model_file=None, **kwargs):
+    def __init__(
+        self, model_file=None, dvclive: Optional[Live] = None, **kwargs
+    ):
         super().__init__()
         self.model_file = model_file
-        self.dvclive = Live(**kwargs)
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     def on_log(
         self,

--- a/src/dvclive/lgbm.py
+++ b/src/dvclive/lgbm.py
@@ -1,11 +1,15 @@
+from typing import Optional
+
 from dvclive import Live
 
 
 class DvcLiveCallback:
-    def __init__(self, model_file=None, **kwargs):
+    def __init__(
+        self, model_file=None, dvclive: Optional[Live] = None, **kwargs
+    ):
         super().__init__()
         self.model_file = model_file
-        self.dvclive = Live(**kwargs)
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     def __call__(self, env):
         for eval_result in env.evaluation_result_list:

--- a/src/dvclive/xgb.py
+++ b/src/dvclive/xgb.py
@@ -1,14 +1,22 @@
+from typing import Optional
+
 from xgboost.callback import TrainingCallback
 
 from dvclive import Live
 
 
 class DvcLiveCallback(TrainingCallback):
-    def __init__(self, metric_data, model_file=None, **kwargs):
+    def __init__(
+        self,
+        metric_data,
+        model_file=None,
+        dvclive: Optional[Live] = None,
+        **kwargs
+    ):
         super().__init__()
         self._metric_data = metric_data
         self.model_file = model_file
-        self.dvclive = Live(**kwargs)
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     def after_iteration(self, model, epoch, evals_log):
         for key, values in evals_log[self._metric_data].items():

--- a/tests/test_catalyst.py
+++ b/tests/test_catalyst.py
@@ -7,6 +7,7 @@ from catalyst.utils.torch import get_available_engine
 from torch import nn, optim
 from torch.utils.data import DataLoader
 
+from dvclive import Live
 from dvclive.catalyst import DvcLiveCallback
 from dvclive.data import Scalar
 
@@ -93,3 +94,10 @@ def test_catalyst_model_file(tmp_dir, runner, loaders):
         load_best_on_end=True,
     )
     assert (tmp_dir / "model.pth").is_file()
+
+
+def test_catalyst_pass_logger():
+    logger = Live("train_logs")
+
+    assert DvcLiveCallback().dvclive is not logger
+    assert DvcLiveCallback(dvclive=logger).dvclive is logger

--- a/tests/test_fastai.py
+++ b/tests/test_fastai.py
@@ -9,6 +9,7 @@ from fastai.tabular.all import (
     tabular_learner,
 )
 
+from dvclive import Live
 from dvclive.data.scalar import Scalar
 from dvclive.fastai import DvcLiveCallback
 
@@ -56,3 +57,10 @@ def test_fastai_model_file(tmp_dir, data_loader):
     learn.model_dir = os.path.abspath("./")
     learn.fit_one_cycle(2, cbs=[DvcLiveCallback("model")])
     assert (tmp_dir / "model.pth").is_file()
+
+
+def test_fastai_pass_logger():
+    logger = Live("train_logs")
+
+    assert DvcLiveCallback().dvclive is not logger
+    assert DvcLiveCallback(dvclive=logger).dvclive is logger

--- a/tests/test_huggingface.py
+++ b/tests/test_huggingface.py
@@ -10,6 +10,7 @@ from transformers import (
     TrainingArguments,
 )
 
+from dvclive import Live
 from dvclive.data.scalar import Scalar
 from dvclive.huggingface import DvcLiveCallback
 from dvclive.utils import parse_scalars
@@ -115,3 +116,10 @@ def test_huggingface_model_file(tmp_dir, model, args, data, tokenizer, mocker):
 
     assert (model_path / "tokenizer.json").exists()
     assert tokernizer_save.call_count == 2
+
+
+def test_huggingface_pass_logger():
+    logger = Live("train_logs")
+
+    assert DvcLiveCallback().dvclive is not logger
+    assert DvcLiveCallback(dvclive=logger).dvclive is logger

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -56,25 +56,11 @@ def test_keras_callback(tmp_dir, xor_model, capture_wrap):
     assert os.path.join(scalars, "eval", "accuracy.tsv") in logs
 
 
-def test_keras_callback_pass_logger(tmp_dir, xor_model, capture_wrap):
-    model, x, y = xor_model()
-
+def test_keras_callback_pass_logger():
     logger = Live("train_logs")
 
-    model.fit(
-        x,
-        y,
-        epochs=1,
-        batch_size=1,
-        validation_split=0.2,
-        callbacks=[DvcLiveCallback(dvclive=logger)],
-    )
-    assert os.path.exists(logger.dir)
-    logs, _ = parse_scalars(logger)
-
-    scalars = os.path.join(logger.dir, Scalar.subfolder)
-    assert os.path.join(scalars, "train", "accuracy.tsv") in logs
-    assert os.path.join(scalars, "eval", "accuracy.tsv") in logs
+    assert DvcLiveCallback().dvclive is not logger
+    assert DvcLiveCallback(dvclive=logger).dvclive is logger
 
 
 @pytest.mark.parametrize("save_weights_only", (True, False))

--- a/tests/test_lgbm.py
+++ b/tests/test_lgbm.py
@@ -8,6 +8,7 @@ import pytest
 from sklearn import datasets
 from sklearn.model_selection import train_test_split
 
+from dvclive import Live
 from dvclive.lgbm import DvcLiveCallback
 from dvclive.utils import parse_scalars
 
@@ -73,3 +74,10 @@ def test_lgbm_model_file(tmp_dir, model_params, iris_data):
     preds2 = model2.predict(iris_data[1][0])
     preds2 = np.argmax(preds2, axis=1)
     assert np.sum(np.abs(preds2 - preds)) == 0
+
+
+def test_lgbm_pass_logger():
+    logger = Live("train_logs")
+
+    assert DvcLiveCallback().dvclive is not logger
+    assert DvcLiveCallback(dvclive=logger).dvclive is logger

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -6,6 +6,7 @@ import pytest
 import xgboost as xgb
 from sklearn import datasets
 
+from dvclive import Live
 from dvclive.utils import parse_scalars
 from dvclive.xgb import DvcLiveCallback
 
@@ -55,3 +56,10 @@ def test_xgb_model_file(tmp_dir, train_params, iris_data):
     model2 = xgb.Booster(model_file="model_xgb.json")
     preds2 = model2.predict(iris_data)
     assert np.sum(np.abs(preds2 - preds)) == 0
+
+
+def test_xgb_pass_logger():
+    logger = Live("train_logs")
+
+    assert DvcLiveCallback("eval_data").dvclive is not logger
+    assert DvcLiveCallback("eval_data", dvclive=logger).dvclive is logger


### PR DESCRIPTION
https://github.com/iterative/dvclive/pull/302 followup to do the same for other loggers

+ it simplifies the Keras test

Next steps:

- MMCV requires a separate PR in their repo
- Lighting logger looks very different from the others + some cleanup can be done. But it already has a way to pass a live instance via `experiment` parameter
- Update docs