### PR TITLE
live: Revisit output names and structure.

### DIFF
--- a/src/dvclive/data/__init__.py
+++ b/src/dvclive/data/__init__.py
@@ -1,6 +1,6 @@
 from .image import Image
+from .metric import Metric
 from .plot import Calibration, ConfusionMatrix, Det, PrecisionRecall, Roc
-from .scalar import Scalar
 from .utils import NumpyEncoder  # noqa: F401
 
 PLOTS = {
@@ -10,4 +10,4 @@ PLOTS = {
     "precision_recall": PrecisionRecall,
     "roc": Roc,
 }
-DATA_TYPES = (*PLOTS.values(), Scalar, Image)
+DATA_TYPES = (*PLOTS.values(), Metric, Image)

--- a/src/dvclive/data/metric.py
+++ b/src/dvclive/data/metric.py
@@ -10,9 +10,9 @@ from .base import Data
 from .utils import NUMPY_SCALARS
 
 
-class Scalar(Data):
+class Metric(Data):
     suffixes = [".csv", ".tsv"]
-    subfolder = "scalars"
+    subfolder = "metrics"
 
     @staticmethod
     def could_log(val: object) -> bool:

--- a/src/dvclive/data/plot.py
+++ b/src/dvclive/data/plot.py
@@ -6,7 +6,7 @@ from .base import Data
 
 class Plot(Data):
     suffixes = [".json"]
-    subfolder = "plots"
+    subfolder = "data_series"
 
     @property
     def output_path(self) -> Path:

--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -8,7 +8,7 @@ from dvc_render.markdown import render_markdown
 from dvc_render.table import TableRenderer
 from dvc_render.vega import VegaRenderer
 
-from dvclive.data import PLOTS, Image, Scalar
+from dvclive.data import PLOTS, Image, Metric
 from dvclive.data.plot import Plot
 from dvclive.serialize import load_yaml
 from dvclive.utils import parse_tsv
@@ -17,20 +17,20 @@ if TYPE_CHECKING:
     from dvclive import Live
 
 
-def get_scalar_renderers(scalars_folder):
+def get_scalar_renderers(metrics_path):
     renderers = []
-    for suffix in Scalar.suffixes:
-        for file in Path(scalars_folder).rglob(f"*{suffix}"):
+    for suffix in Metric.suffixes:
+        for file in metrics_path.rglob(f"*{suffix}"):
             data = parse_tsv(file)
             for row in data:
                 row["rev"] = "workspace"
 
-            y = file.relative_to(scalars_folder).with_suffix("")
+            y = file.relative_to(metrics_path).with_suffix("")
             y = y.as_posix()
 
-            name = file.relative_to(scalars_folder.parent).with_suffix("")
+            name = file.relative_to(metrics_path.parent).with_suffix("")
             name = name.as_posix()
-            name = name.replace(scalars_folder.name, "static")
+            name = name.replace(metrics_path.name, "static")
 
             properties = {"x": "step", "y": y}
             renderers.append(VegaRenderer(data, name, **properties))
@@ -71,12 +71,12 @@ def get_plot_renderers(plots_folder):
 
 
 def get_metrics_renderers(dvclive_summary):
-    summary_path = Path(dvclive_summary)
-    if summary_path.exists():
+    metrics_path = Path(dvclive_summary)
+    if metrics_path.exists():
         return [
             TableRenderer(
-                [json.loads(summary_path.read_text(encoding="utf-8"))],
-                summary_path.name,
+                [json.loads(metrics_path.read_text(encoding="utf-8"))],
+                metrics_path.name,
             )
         ]
     return []
@@ -95,14 +95,14 @@ def get_params_renderers(dvclive_params):
 
 
 def make_report(dvclive: "Live"):
-    dvclive_path = Path(dvclive.dir)
+    plots_path = Path(dvclive.plots_path)
 
     renderers = []
     renderers.extend(get_params_renderers(dvclive.params_path))
-    renderers.extend(get_metrics_renderers(dvclive.summary_path))
-    renderers.extend(get_scalar_renderers(dvclive_path / Scalar.subfolder))
-    renderers.extend(get_image_renderers(dvclive_path / Image.subfolder))
-    renderers.extend(get_plot_renderers(dvclive_path / Plot.subfolder))
+    renderers.extend(get_metrics_renderers(dvclive.metrics_path))
+    renderers.extend(get_scalar_renderers(plots_path / Metric.subfolder))
+    renderers.extend(get_image_renderers(plots_path / Image.subfolder))
+    renderers.extend(get_plot_renderers(plots_path / Plot.subfolder))
 
     if dvclive.report_mode == "html":
         render_html(renderers, dvclive.report_path, refresh_seconds=5)

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from dvclive.env import STUDIO_ENDPOINT
-from dvclive.utils import parse_scalars
+from dvclive.utils import parse_metrics
 
 
 def _get_unsent_datapoints(plot, latest_step):
@@ -28,14 +28,14 @@ def _to_dvc_format(plots):
 
 
 def _get_updates(live):
-    plots, metrics = parse_scalars(live)
+    plots, metrics = parse_metrics(live)
     latest_step = live._latest_studio_step  # pylint: disable=protected-access
 
     for name, plot in plots.items():
         datapoints = _get_unsent_datapoints(plot, latest_step)
         plots[name] = _cast_to_numbers(datapoints)
 
-    metrics = {live.summary_path: {"data": metrics}}
+    metrics = {live.metrics_path: {"data": metrics}}
     plots = _to_dvc_format(plots)
     return metrics, plots
 

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -107,13 +107,13 @@ def parse_json(path):
         return json.load(fd)
 
 
-def parse_scalars(live):
-    from .data import Scalar
+def parse_metrics(live):
+    from .data import Metric
 
-    live_dir = Path(live.dir)
+    plots_path = Path(live.plots_path)
     history = {}
-    for suffix in Scalar.suffixes:
-        for scalar_file in live_dir.rglob(f"*{suffix}"):
+    for suffix in Metric.suffixes:
+        for scalar_file in plots_path.rglob(f"*{suffix}"):
             history[str(scalar_file)] = parse_tsv(scalar_file)
-    latest = parse_json(live.summary_path)
+    latest = parse_json(live.metrics_path)
     return history, latest

--- a/tests/test_catalyst.py
+++ b/tests/test_catalyst.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader
 
 from dvclive import Live
 from dvclive.catalyst import DvcLiveCallback
-from dvclive.data import Scalar
+from dvclive.data import Metric
 
 # pylint: disable=redefined-outer-name, unused-argument
 
@@ -61,8 +61,8 @@ def test_catalyst_callback(tmp_dir, runner, loaders):
 
     assert os.path.exists("dvclive")
 
-    train_path = tmp_dir / "dvclive" / Scalar.subfolder / "train"
-    valid_path = tmp_dir / "dvclive" / Scalar.subfolder / "valid"
+    train_path = tmp_dir / "dvclive" / "plots" / Metric.subfolder / "train"
+    valid_path = tmp_dir / "dvclive" / "plots" / Metric.subfolder / "valid"
 
     assert train_path.is_dir()
     assert valid_path.is_dir()

--- a/tests/test_data/test_image.py
+++ b/tests/test_data/test_image.py
@@ -8,40 +8,44 @@ from dvclive.data import Image as LiveImage
 
 
 def test_PIL(tmp_dir):
-    dvclive = Live()
+    live = Live()
     img = Image.new("RGB", (500, 500), (250, 250, 250))
-    dvclive.log_image("image.png", img)
+    live.log_image("image.png", img)
 
-    assert (tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png").exists()
+    assert (
+        tmp_dir / live.plots_path / LiveImage.subfolder / "image.png"
+    ).exists()
 
 
 def test_invalid_extension(tmp_dir):
-    dvclive = Live()
+    live = Live()
     img = Image.new("RGB", (500, 500), (250, 250, 250))
     with pytest.raises(ValueError):
-        dvclive.log_image("image.foo", img)
+        live.log_image("image.foo", img)
 
 
 @pytest.mark.parametrize("shape", [(500, 500), (500, 500, 3), (500, 500, 4)])
 def test_numpy(tmp_dir, shape):
-    dvclive = Live()
+    live = Live()
     img = np.ones(shape, np.uint8) * 255
-    dvclive.log_image("image.png", img)
+    live.log_image("image.png", img)
 
-    assert (tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png").exists()
+    assert (
+        tmp_dir / live.plots_path / LiveImage.subfolder / "image.png"
+    ).exists()
 
 
 def test_step_formatting(tmp_dir):
-    dvclive = Live()
+    live = Live()
     img = np.ones((500, 500, 3), np.uint8)
     for _ in range(3):
-        dvclive.log_image("image.png", img)
-        dvclive.next_step()
+        live.log_image("image.png", img)
+        live.next_step()
 
     for step in range(3):
         assert (
             tmp_dir
-            / dvclive.dir
+            / live.plots_path
             / LiveImage.subfolder
             / str(step)
             / "image.png"
@@ -52,32 +56,36 @@ def test_step_rename(tmp_dir, mocker):
     from pathlib import Path
 
     rename = mocker.spy(Path, "rename")
-    dvclive = Live()
+    live = Live()
     img = np.ones((500, 500, 3), np.uint8)
-    dvclive.log_image("image.png", img)
-    assert (tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png").exists()
+    live.log_image("image.png", img)
+    assert (
+        tmp_dir / live.plots_path / LiveImage.subfolder / "image.png"
+    ).exists()
 
-    dvclive.next_step()
+    live.next_step()
 
     assert not (
-        tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png"
+        tmp_dir / live.plots_path / LiveImage.subfolder / "image.png"
     ).exists()
     assert (
-        tmp_dir / dvclive.dir / LiveImage.subfolder / "0" / "image.png"
+        tmp_dir / live.plots_path / LiveImage.subfolder / "0" / "image.png"
     ).exists()
     rename.assert_called_once_with(
-        Path(dvclive.dir) / LiveImage.subfolder / "image.png",
-        Path(dvclive.dir) / LiveImage.subfolder / "0" / "image.png",
+        Path(live.plots_path) / LiveImage.subfolder / "image.png",
+        Path(live.plots_path) / LiveImage.subfolder / "0" / "image.png",
     )
 
 
 def test_cleanup(tmp_dir):
-    dvclive = Live()
+    live = Live()
     img = np.ones((500, 500, 3), np.uint8)
-    dvclive.log_image("image.png", img)
+    live.log_image("image.png", img)
 
-    assert (tmp_dir / dvclive.dir / LiveImage.subfolder / "image.png").exists()
+    assert (
+        tmp_dir / live.plots_path / LiveImage.subfolder / "image.png"
+    ).exists()
 
     Live()
 
-    assert not (tmp_dir / dvclive.dir / LiveImage.subfolder).exists()
+    assert not (tmp_dir / live.plots_path / LiveImage.subfolder).exists()

--- a/tests/test_data/test_plot.py
+++ b/tests/test_data/test_plot.py
@@ -28,7 +28,7 @@ def y_true_y_pred_y_score():
 
 def test_log_calibration_curve(tmp_dir, y_true_y_pred_y_score, mocker):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, _, y_score = y_true_y_pred_y_score
 
@@ -43,7 +43,7 @@ def test_log_calibration_curve(tmp_dir, y_true_y_pred_y_score, mocker):
 
 def test_log_det_curve(tmp_dir, y_true_y_pred_y_score, mocker):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, _, y_score = y_true_y_pred_y_score
 
@@ -57,7 +57,7 @@ def test_log_det_curve(tmp_dir, y_true_y_pred_y_score, mocker):
 
 def test_log_roc_curve(tmp_dir, y_true_y_pred_y_score, mocker):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, _, y_score = y_true_y_pred_y_score
 
@@ -71,7 +71,7 @@ def test_log_roc_curve(tmp_dir, y_true_y_pred_y_score, mocker):
 
 def test_log_prc_curve(tmp_dir, y_true_y_pred_y_score, mocker):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, _, y_score = y_true_y_pred_y_score
 
@@ -85,7 +85,7 @@ def test_log_prc_curve(tmp_dir, y_true_y_pred_y_score, mocker):
 
 def test_log_confusion_matrix(tmp_dir, y_true_y_pred_y_score, mocker):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, y_pred, _ = y_true_y_pred_y_score
 
@@ -101,7 +101,7 @@ def test_log_confusion_matrix(tmp_dir, y_true_y_pred_y_score, mocker):
 
 def test_step_exception(tmp_dir, y_true_y_pred_y_score):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, y_pred, _ = y_true_y_pred_y_score
 
@@ -126,7 +126,7 @@ def test_dump_kwargs(tmp_dir, y_true_y_pred_y_score, mocker):
 
 def test_cleanup(tmp_dir, y_true_y_pred_y_score):
     live = Live()
-    out = tmp_dir / live.dir / Plot.subfolder
+    out = tmp_dir / live.plots_path / Plot.subfolder
 
     y_true, y_pred, _ = y_true_y_pred_y_score
 
@@ -136,4 +136,4 @@ def test_cleanup(tmp_dir, y_true_y_pred_y_score):
 
     Live()
 
-    assert not (tmp_dir / live.dir / Plot.subfolder).exists()
+    assert not (tmp_dir / live.plots_path / Plot.subfolder).exists()

--- a/tests/test_data/test_scalar.py
+++ b/tests/test_data/test_scalar.py
@@ -5,7 +5,7 @@ import pytest
 
 # pylint: disable=unused-argument
 from dvclive import Live
-from dvclive.data.scalar import Scalar
+from dvclive.data.metric import Metric
 from dvclive.data.utils import NUMPY_INTS, NUMPY_SCALARS
 from dvclive.utils import parse_tsv
 
@@ -18,9 +18,9 @@ def test_numpy(tmp_dir, dtype):
     live.log("scalar", scalar)
     live.next_step()
 
-    parsed = json.loads((tmp_dir / live.summary_path).read_text())
+    parsed = json.loads((tmp_dir / live.metrics_path).read_text())
     assert isinstance(parsed["scalar"], int if dtype in NUMPY_INTS else float)
-    tsv_file = tmp_dir / live.dir / Scalar.subfolder / "scalar.tsv"
+    tsv_file = tmp_dir / live.plots_path / Metric.subfolder / "scalar.tsv"
     tsv_val = parse_tsv(tsv_file)[0]["scalar"]
     assert tsv_val == str(scalar)
 
@@ -32,7 +32,9 @@ def test_name_with_dot(tmp_dir):
     live.log("scalar.foo.bar", 1.0)
     live.next_step()
 
-    tsv_file = tmp_dir / live.dir / Scalar.subfolder / "scalar.foo.bar.tsv"
+    tsv_file = (
+        tmp_dir / live.plots_path / Metric.subfolder / "scalar.foo.bar.tsv"
+    )
     assert tsv_file.exists()
     tsv_val = parse_tsv(tsv_file)[0]["scalar.foo.bar"]
     assert tsv_val == "1.0"

--- a/tests/test_fastai.py
+++ b/tests/test_fastai.py
@@ -10,7 +10,7 @@ from fastai.tabular.all import (
 )
 
 from dvclive import Live
-from dvclive.data.scalar import Scalar
+from dvclive.data.metric import Metric
 from dvclive.fastai import DvcLiveCallback
 
 # pylint: disable=redefined-outer-name, unused-argument
@@ -40,16 +40,19 @@ def data_loader():
 def test_fastai_callback(tmp_dir, data_loader):
     learn = tabular_learner(data_loader, metrics=accuracy)
     learn.model_dir = os.path.abspath("./")
-    learn.fit_one_cycle(2, cbs=[DvcLiveCallback("model")])
+    callback = DvcLiveCallback("model")
+    live = callback.dvclive
+    learn.fit_one_cycle(2, cbs=[callback])
 
-    assert os.path.exists("dvclive")
+    assert os.path.exists(live.dir)
 
-    train_path = tmp_dir / "dvclive" / Scalar.subfolder / "train"
-    valid_path = tmp_dir / "dvclive" / Scalar.subfolder / "eval"
+    metrics_path = tmp_dir / live.plots_path / Metric.subfolder
+    train_path = metrics_path / "train"
+    valid_path = metrics_path / "eval"
 
     assert train_path.is_dir()
     assert valid_path.is_dir()
-    assert (tmp_dir / "dvclive" / Scalar.subfolder / "accuracy.tsv").exists()
+    assert (metrics_path / "accuracy.tsv").exists()
 
 
 def test_fastai_model_file(tmp_dir, data_loader):

--- a/tests/test_huggingface.py
+++ b/tests/test_huggingface.py
@@ -12,9 +12,9 @@ from transformers import (
 )
 
 from dvclive import Live
-from dvclive.data.scalar import Scalar
+from dvclive.data.metric import Metric
 from dvclive.huggingface import DvcLiveCallback
-from dvclive.utils import parse_scalars
+from dvclive.utils import parse_metrics
 
 # pylint: disable=redefined-outer-name, unused-argument, no-value-for-parameter
 
@@ -113,13 +113,14 @@ def test_huggingface_integration(tmp_dir, model, args, data):
     trainer.add_callback(callback)
     trainer.train()
 
-    assert os.path.exists("dvclive")
+    live = callback.dvclive
+    assert os.path.exists(live.dir)
 
-    logs, _ = parse_scalars(callback.dvclive)
+    logs, _ = parse_metrics(live)
 
     assert len(logs) == 10
 
-    scalars = os.path.join("dvclive", Scalar.subfolder)
+    scalars = os.path.join(live.plots_path, Metric.subfolder)
     assert os.path.join(scalars, "eval", "foo.tsv") in logs
     assert os.path.join(scalars, "eval", "loss.tsv") in logs
     assert os.path.join(scalars, "train", "loss.tsv") in logs

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -3,9 +3,9 @@ import os
 import pytest
 
 from dvclive import Live
-from dvclive.data.scalar import Scalar
+from dvclive.data.metric import Metric
 from dvclive.keras import DvcLiveCallback
-from dvclive.utils import parse_scalars
+from dvclive.utils import parse_metrics
 
 # pylint: disable=unused-argument, no-name-in-module, redefined-outer-name
 
@@ -49,9 +49,9 @@ def test_keras_callback(tmp_dir, xor_model, capture_wrap):
     )
 
     assert os.path.exists("dvclive")
-    logs, _ = parse_scalars(callback.dvclive)
+    logs, _ = parse_metrics(callback.dvclive)
 
-    scalars = os.path.join("dvclive", Scalar.subfolder)
+    scalars = os.path.join(callback.dvclive.plots_path, Metric.subfolder)
     assert os.path.join(scalars, "train", "accuracy.tsv") in logs
     assert os.path.join(scalars, "eval", "accuracy.tsv") in logs
 

--- a/tests/test_lgbm.py
+++ b/tests/test_lgbm.py
@@ -10,7 +10,7 @@ from sklearn.model_selection import train_test_split
 
 from dvclive import Live
 from dvclive.lgbm import DvcLiveCallback
-from dvclive.utils import parse_scalars
+from dvclive.utils import parse_metrics
 
 # pylint: disable=redefined-outer-name, unused-argument
 
@@ -49,7 +49,7 @@ def test_lgbm_integration(tmp_dir, model_params, iris_data):
 
     assert os.path.exists("dvclive")
 
-    logs, _ = parse_scalars(callback.dvclive)
+    logs, _ = parse_metrics(callback.dvclive)
     assert len(logs) == 1
     assert len(list(logs.values())[0]) == 5
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -8,9 +8,9 @@ from torch.nn import functional as F
 from torch.optim import Adam
 from torch.utils.data import DataLoader, Dataset
 
-from dvclive.data.scalar import Scalar
+from dvclive.data.metric import Metric
 from dvclive.lightning import DvcLiveLogger
-from dvclive.utils import parse_scalars
+from dvclive.utils import parse_metrics
 
 # pylint: disable=redefined-outer-name, unused-argument
 
@@ -100,8 +100,10 @@ def test_lightning_integration(tmp_dir):
     assert os.path.exists("logs")
     assert not os.path.exists("DvcLiveLogger")
 
-    scalars = os.path.join(dvclive_logger.experiment.dir, Scalar.subfolder)
-    logs, _ = parse_scalars(dvclive_logger.experiment)
+    scalars = os.path.join(
+        dvclive_logger.experiment.plots_path, Metric.subfolder
+    )
+    logs, _ = parse_metrics(dvclive_logger.experiment)
 
     assert len(logs) == 3
     assert os.path.join(scalars, "train", "epoch", "loss.tsv") in logs

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -6,7 +6,7 @@ from PIL import Image
 
 from dvclive import Live
 from dvclive.data import Image as LiveImage
-from dvclive.data import Scalar
+from dvclive.data import Metric
 from dvclive.data.plot import ConfusionMatrix, Plot
 from dvclive.env import DVCLIVE_OPEN
 from dvclive.report import (
@@ -34,7 +34,7 @@ def test_get_renderers(tmp_dir, mocker):
     live.log_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])
 
     image_renderers = get_image_renderers(
-        tmp_dir / live.dir / LiveImage.subfolder
+        tmp_dir / live.plots_path / LiveImage.subfolder
     )
     assert len(image_renderers) == 2
     image_renderers = sorted(
@@ -46,7 +46,7 @@ def test_get_renderers(tmp_dir, mocker):
         ]
 
     scalar_renderers = get_scalar_renderers(
-        tmp_dir / live.dir / Scalar.subfolder
+        tmp_dir / live.plots_path / Metric.subfolder
     )
     assert len(scalar_renderers) == 1
     assert scalar_renderers[0].datapoints == [
@@ -66,7 +66,9 @@ def test_get_renderers(tmp_dir, mocker):
     assert scalar_renderers[0].properties["y"] == "foo/bar"
     assert scalar_renderers[0].name == "static/foo/bar"
 
-    plot_renderers = get_plot_renderers(tmp_dir / live.dir / Plot.subfolder)
+    plot_renderers = get_plot_renderers(
+        tmp_dir / live.plots_path / Plot.subfolder
+    )
     assert len(plot_renderers) == 1
     assert plot_renderers[0].datapoints == [
         {"actual": "0", "rev": "workspace", "predicted": "1"},
@@ -76,7 +78,7 @@ def test_get_renderers(tmp_dir, mocker):
     ]
     assert plot_renderers[0].properties == ConfusionMatrix.get_properties()
 
-    metrics_renderer = get_metrics_renderers(live.summary_path)[0]
+    metrics_renderer = get_metrics_renderers(live.metrics_path)[0]
     assert metrics_renderer.datapoints == [{"step": 1, "foo": {"bar": 1}}]
 
     params_renderer = get_params_renderers(live.params_path)[0]
@@ -101,7 +103,7 @@ def test_report_init(monkeypatch):
 
 
 @pytest.mark.parametrize("mode", ["html", "md"])
-def test_make_report(tmp_dir, mode):
+def test_make_report(tmp_dir, mode, mocker):
     live = Live(report=mode)
     for i in range(3):
         live.log("foobar", i)

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from dvclive import Live, env
-from dvclive.data import Scalar
+from dvclive.data import Metric
 
 
 @pytest.mark.studio
@@ -20,7 +20,7 @@ def test_post_to_studio(tmp_dir, mocker, monkeypatch):
 
     live = Live()
 
-    scalar_path = os.path.join(live.dir, Scalar.subfolder, "foo.tsv")
+    scalar_path = os.path.join(live.plots_path, Metric.subfolder, "foo.tsv")
 
     mocked_post.assert_called_with(
         "https://0.0.0.0",
@@ -47,7 +47,7 @@ def test_post_to_studio(tmp_dir, mocker, monkeypatch):
             "repo_url": "STUDIO_REPO_URL",
             "rev": mocker.ANY,
             "step": 0,
-            "metrics": {"dvclive.json": {"data": {"step": 0, "foo": 1}}},
+            "metrics": {live.metrics_path: {"data": {"step": 0, "foo": 1}}},
             "plots": {
                 scalar_path: {
                     "data": [{"timestamp": mocker.ANY, "step": 0, "foo": 1.0}]
@@ -72,7 +72,7 @@ def test_post_to_studio(tmp_dir, mocker, monkeypatch):
             "repo_url": "STUDIO_REPO_URL",
             "rev": mocker.ANY,
             "step": 1,
-            "metrics": {"dvclive.json": {"data": {"step": 1, "foo": 2}}},
+            "metrics": {live.metrics_path: {"data": {"step": 1, "foo": 2}}},
             "plots": {
                 scalar_path: {
                     "data": [{"timestamp": mocker.ANY, "step": 1, "foo": 2.0}]
@@ -117,7 +117,7 @@ def test_post_to_studio_failed_data_request(tmp_dir, mocker, monkeypatch):
 
     live = Live()
 
-    scalar_path = os.path.join(live.dir, Scalar.subfolder, "foo.tsv")
+    scalar_path = os.path.join(live.plots_path, Metric.subfolder, "foo.tsv")
 
     error_response = mocker.MagicMock()
     error_response.status_code = 400
@@ -135,7 +135,7 @@ def test_post_to_studio_failed_data_request(tmp_dir, mocker, monkeypatch):
             "repo_url": "STUDIO_REPO_URL",
             "rev": mocker.ANY,
             "step": 1,
-            "metrics": {"dvclive.json": {"data": {"step": 1, "foo": 2}}},
+            "metrics": {live.metrics_path: {"data": {"step": 1, "foo": 2}}},
             "plots": {
                 scalar_path: {
                     "data": [

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -7,7 +7,7 @@ import xgboost as xgb
 from sklearn import datasets
 
 from dvclive import Live
-from dvclive.utils import parse_scalars
+from dvclive.utils import parse_metrics
 from dvclive.xgb import DvcLiveCallback
 
 # pylint: disable=redefined-outer-name, unused-argument
@@ -38,7 +38,7 @@ def test_xgb_integration(tmp_dir, train_params, iris_data):
 
     assert os.path.exists("dvclive")
 
-    logs, _ = parse_scalars(callback.dvclive)
+    logs, _ = parse_metrics(callback.dvclive)
     assert len(logs) == 1
     assert len(list(logs.values())[0]) == 5
 


### PR DESCRIPTION
Applied https://github.com/iterative/dvclive/issues/246#issuecomment-1258582603

Closes #246

Note this targets branch `1.0`

---

For this script:

```python
import random

from dvclive import Live
from PIL import Image
from PIL import ImageDraw 

live = Live()

for i in range(2):
    live.log("foobar", i + random.random())
    live.log("foo/bar", i + random.random())

    img = Image.new("RGB", (50, 50), (255, 255, 255))
    draw = ImageDraw.Draw(img)
    draw.text((20, 20), f"{i  + random.random():.1f}", (0,0,0))
    live.log_image("img.png", img)

    live.next_step()

live.set_step(None)
live.log_plot("confusion_matrix", [0, 0, 1, 1], [0, 1, 0, 1])
```

This is the output:

```
dvclive
├── metrics.json
├── plots
│   ├── data_series
│   │   └── confusion_matrix.json
│   ├── images
│   │   ├── 0
│   │   │   └── img.png
│   │   └── 1
│   │       └── img.png
│   └── metrics
│       ├── foo
│       │   └── bar.tsv
│       └── foobar.tsv
└── report.html
```