### PR TITLE
live: Moved all `make_{x}` to `next_step()`.

### DIFF
--- a/src/dvclive/catalyst.py
+++ b/src/dvclive/catalyst.py
@@ -26,5 +26,4 @@ class DVCLiveCallback(Callback):
                 scheduler=runner.scheduler,
             )
             utils.save_checkpoint(checkpoint, self.model_file)
-        self.live.make_report()
         self.live.next_step()

--- a/src/dvclive/fastai.py
+++ b/src/dvclive/fastai.py
@@ -22,5 +22,4 @@ class DVCLiveCallback(Callback):
 
         if self.model_file:
             self.learn.save(self.model_file)
-        self.live.make_report()
         self.live.next_step()

--- a/src/dvclive/huggingface.py
+++ b/src/dvclive/huggingface.py
@@ -27,7 +27,6 @@ class DVCLiveCallback(TrainerCallback):
         logs = kwargs["logs"]
         for key, value in logs.items():
             self.live.log_metric(standardize_metric_name(key, __name__), value)
-        self.live.make_report()
         self.live.next_step()
 
     def on_epoch_end(

--- a/src/dvclive/keras.py
+++ b/src/dvclive/keras.py
@@ -53,5 +53,4 @@ class DVCLiveCallback(Callback):
                 self.model.save_weights(self.model_file)
             else:
                 self.model.save(self.model_file)
-        self.live.make_report()
         self.live.next_step()

--- a/src/dvclive/lgbm.py
+++ b/src/dvclive/lgbm.py
@@ -17,5 +17,4 @@ class DVCLiveCallback:
 
         if self.model_file:
             env.model.save_model(self.model_file)
-        self.live.make_report()
         self.live.next_step()

--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -69,5 +69,4 @@ class DVCLiveLogger(Logger):
                 metric_val = metric_val.cpu().detach().item()
             metric_name = standardize_metric_name(metric_name, __name__)
             self.experiment.log_metric(name=metric_name, val=metric_val)
-        self.experiment.make_report()
         self.experiment.next_step()

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -5,7 +5,7 @@ from dvclive.utils import parse_metrics
 
 
 def _get_unsent_datapoints(plot, latest_step):
-    return [x for x in plot if int(x["step"]) >= latest_step]
+    return [x for x in plot if int(x["step"]) > latest_step]
 
 
 def _cast_to_numbers(datapoints):

--- a/src/dvclive/xgb.py
+++ b/src/dvclive/xgb.py
@@ -25,5 +25,4 @@ class DVCLiveCallback(TrainingCallback):
             self.live.log_metric(key, latest_metric)
         if self.model_file:
             model.save_model(self.model_file)
-        self.live.make_report()
         self.live.next_step()


### PR DESCRIPTION
`log_metric` now stores logged value in `live.summary` but doesn't call `make_summary` as before.

Closes #238
Closes #232