### PR TITLE
fast.ai: Handle resuming.

### DIFF
--- a/src/dvclive/fastai.py
+++ b/src/dvclive/fastai.py
@@ -7,22 +7,36 @@ from dvclive.utils import standardize_metric_name
 
 
 class DVCLiveCallback(Callback):
-    def __init__(self, model_file=None, live: Optional[Live] = None, **kwargs):
+    def __init__(
+        self,
+        model_file: Optional[str] = None,
+        with_opt: bool = False,
+        live: Optional[Live] = None,
+        **kwargs
+    ):
         super().__init__()
         self.model_file = model_file
+        self.with_opt = with_opt
         self.live = live if live is not None else Live(**kwargs)
 
     def after_epoch(self):
+        logged_metrics = False
         for key, value in zip(
             self.learn.recorder.metric_names, self.learn.recorder.log
         ):
+            if key == "epoch":
+                continue
             self.live.log_metric(
                 standardize_metric_name(key, __name__), float(value)
             )
+            logged_metrics = True
 
-        if self.model_file:
-            self.learn.save(self.model_file)
-        self.live.next_step()
+        # When resuming (i.e. passing `start_epoch` to learner)
+        # fast.ai calls after_epoch but we don't want to increase the step.
+        if logged_metrics:
+            if self.model_file:
+                self.learn.save(self.model_file, with_opt=self.with_opt)
+            self.live.next_step()
 
     def after_fit(self):
         self.live.end()


### PR DESCRIPTION
Found some bugs while working on https://github.com/iterative/dvc-get-started-cv/pull/59 .

- Use the occasion to also remove the redundant logging of `epoch` as a metric.
- Expose `with_opt` option.
- Don't increase the step when resuming.