### PR TITLE
lightning: record actual training step

### DIFF
--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -78,7 +78,7 @@ class DVCLiveLogger(Logger):
             try:
                 self.experiment.log_metric(name=metric_name, val=metric_val)
             except DataAlreadyLoggedError:
-                pass # Logs repeat info at end of epochs.
+                pass  # Logs repeat info at end of epochs.
         self.experiment.next_step()
 
     @rank_zero_only

--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -5,6 +5,7 @@ from pytorch_lightning.utilities import rank_zero_only
 from torch import is_tensor
 
 from dvclive import Live
+from dvclive.error import DataAlreadyLoggedError
 from dvclive.utils import standardize_metric_name
 
 
@@ -69,11 +70,15 @@ class DVCLiveLogger(Logger):
             rank_zero_only.rank == 0  # type: ignore
         ), "experiment tried to log from global_rank != 0"
 
+        self.experiment.step = step
         for metric_name, metric_val in metrics.items():
             if is_tensor(metric_val):
                 metric_val = metric_val.cpu().detach().item()
             metric_name = standardize_metric_name(metric_name, __name__)
-            self.experiment.log_metric(name=metric_name, val=metric_val)
+            try:
+                self.experiment.log_metric(name=metric_name, val=metric_val)
+            except DataAlreadyLoggedError:
+                pass # Logs repeat info at end of epochs.
         self.experiment.next_step()
 
     @rank_zero_only

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -145,6 +145,7 @@ def test_lightning_kwargs(tmp_dir):
     assert os.path.exists("dir")
     assert os.path.exists("dir/report.md")
 
+
 def test_lightning_steps(tmp_dir):
     model = LitXOR()
     # Handle kwargs passed to Live.
@@ -159,5 +160,5 @@ def test_lightning_steps(tmp_dir):
 
     with open("logs/metrics.json") as f:
         metrics = json.load(f)
-        assert(metrics["step"] == 8)
-        assert(metrics["epoch"] == 1)
+        assert metrics["step"] == 8
+        assert metrics["epoch"] == 1

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import torch
@@ -143,3 +144,20 @@ def test_lightning_kwargs(tmp_dir):
 
     assert os.path.exists("dir")
     assert os.path.exists("dir/report.md")
+
+def test_lightning_steps(tmp_dir):
+    model = LitXOR()
+    # Handle kwargs passed to Live.
+    dvclive_logger = DVCLiveLogger(dir="logs")
+    trainer = Trainer(
+        logger=dvclive_logger,
+        max_epochs=2,
+        enable_checkpointing=False,
+        log_every_n_steps=2,
+    )
+    trainer.fit(model)
+
+    with open("logs/metrics.json") as f:
+        metrics = json.load(f)
+        assert(metrics["step"] == 8)
+        assert(metrics["epoch"] == 1)

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import torch
@@ -158,7 +157,14 @@ def test_lightning_steps(tmp_dir):
     )
     trainer.fit(model)
 
-    with open("logs/metrics.json") as f:
-        metrics = json.load(f)
-        assert metrics["step"] == 8
-        assert metrics["epoch"] == 1
+    history, latest = parse_metrics(dvclive_logger.experiment)
+    assert latest["step"] == 8
+    assert latest["epoch"] == 1
+
+    scalars = os.path.join(
+        dvclive_logger.experiment.plots_dir, Metric.subfolder
+    )
+    epoch_loss = history[os.path.join(scalars, "train", "epoch", "loss.tsv")]
+    step_loss = history[os.path.join(scalars, "train", "step", "loss.tsv")]
+    assert len(epoch_loss) == 2
+    assert len(step_loss) == 4


### PR DESCRIPTION
Lightning was recording one step per logging iteration, but by default that logs every 50 steps (https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-frequency). This leaves you with 3 different values between epoch, lightning step, and dvclive step.