### PR TITLE
always write dvcyaml

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -100,10 +100,9 @@ def random_exp_name(dvc_repo, baseline_rev):
 
 
 def make_dvcyaml(live):
-    if not os.path.exists(live.dvc_file):
-        dvcyaml = {
-            "metrics": [os.path.relpath(live.metrics_file, live.dir)],
-            "params": [os.path.relpath(live.params_file, live.dir)],
-            "plots": [os.path.relpath(live.plots_dir, live.dir)],
-        }
-        dump_yaml(dvcyaml, live.dvc_file)
+    dvcyaml = {
+        "metrics": [os.path.relpath(live.metrics_file, live.dir)],
+        "params": [os.path.relpath(live.params_file, live.dir)],
+        "plots": [os.path.relpath(live.plots_dir, live.dir)],
+    }
+    dump_yaml(dvcyaml, live.dvc_file)

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -94,6 +94,7 @@ class Live:
 
     def _init_dvc(self):
         self._dvc_repo = get_dvc_repo()
+        make_dvcyaml(self)
         if os.getenv(env.DVC_EXP_BASELINE_REV, None):
             # `dvc exp` execution
             self._baseline_rev = os.getenv(env.DVC_EXP_BASELINE_REV, "")
@@ -110,7 +111,6 @@ class Live:
                     self._exp_name = random_exp_name(
                         self._dvc_repo, self._baseline_rev
                     )
-                    make_dvcyaml(self)
 
     def _init_studio(self):
         if not self._dvc_repo:

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -78,12 +78,10 @@ def test_exp_save_on_end(tmp_dir, mocker, save):
         dvc_repo.experiments.save.assert_called_with(
             name=live._exp_name, include_untracked=live.dir
         )
-        assert (tmp_dir / live.dvc_file).exists()
     else:
         assert live._baseline_rev is None
         assert live._exp_name is None
         dvc_repo.experiments.save.assert_not_called()
-        assert not (tmp_dir / live.dvc_file).exists()
 
 
 def test_exp_save_skip_on_env_vars(tmp_dir, monkeypatch, mocker):
@@ -111,4 +109,3 @@ def test_exp_save_skip_on_dvc_repro(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_not_called()
-    assert not (tmp_dir / live.dvc_file).exists()


### PR DESCRIPTION
Simple approach to #381.

Summary: Write out `dvc.yaml` every time a new live object is initialized.

If we go with this approach, `dvc.api.params_show()` should be updated to not fail if `dvclive/params.yaml` doesn't exist (related to https://github.com/iterative/dvc/issues/7926).