### PR TITLE
write out dvcyaml at each step with relevant outputs

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -100,10 +100,11 @@ def random_exp_name(dvc_repo, baseline_rev):
 
 
 def make_dvcyaml(live):
-    if not os.path.exists(live.dvc_file):
-        dvcyaml = {
-            "metrics": [os.path.relpath(live.metrics_file, live.dir)],
-            "params": [os.path.relpath(live.params_file, live.dir)],
-            "plots": [os.path.relpath(live.plots_dir, live.dir)],
-        }
-        dump_yaml(dvcyaml, live.dvc_file)
+    dvcyaml = {}
+    if live._params:
+        dvcyaml["params"] = [os.path.relpath(live.params_file, live.dir)]
+    if live._metrics:
+        dvcyaml["metrics"] = [os.path.relpath(live.metrics_file, live.dir)]
+    if live._metrics or live._plots or live._images:
+        dvcyaml["plots"] = [os.path.relpath(live.plots_dir, live.dir)]
+    dump_yaml(dvcyaml, live.dvc_file)

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -88,7 +88,8 @@ class Live:
                 Path(self.plots_dir) / plot_type.subfolder, ignore_errors=True
             )
 
-        for f in (self.metrics_file, self.report_file, self.params_file):
+        for f in (self.metrics_file, self.report_file, self.params_file,
+                  self.dvc_file):
             if f and os.path.exists(f):
                 os.remove(f)
 
@@ -110,7 +111,6 @@ class Live:
                     self._exp_name = random_exp_name(
                         self._dvc_repo, self._baseline_rev
                     )
-                    make_dvcyaml(self)
 
     def _init_studio(self):
         if not self._dvc_repo:
@@ -189,6 +189,7 @@ class Live:
             self._step = 0
 
         self.make_summary()
+        make_dvcyaml(self)
         self.make_report()
         self.make_checkpoint()
         self.step += 1
@@ -292,6 +293,7 @@ class Live:
 
     def end(self):
         self.make_summary()
+        make_dvcyaml(self)
         if self._studio_url and self._studio_token:
             if "done" not in self._studio_events_to_skip:
                 if not post_to_studio(self, "done", logger):

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -21,6 +21,20 @@ def test_make_dvcyaml(tmp_dir):
     live = Live()
     make_dvcyaml(live)
 
+    assert load_yaml(live.dvc_file) == {}
+
+    live = Live()
+    make_dvcyaml(live)
+    live.log_param("foo", 1)
+    live.next_step()
+
+    assert load_yaml(live.dvc_file) == {
+        "params": ["params.yaml"],
+    }
+
+    live.log_metric("bar", 2)
+    live.end()
+
     assert load_yaml(live.dvc_file) == {
         "metrics": ["metrics.json"],
         "params": ["params.yaml"],
@@ -83,7 +97,6 @@ def test_exp_save_on_end(tmp_dir, mocker, save):
         assert live._baseline_rev is None
         assert live._exp_name is None
         dvc_repo.experiments.save.assert_not_called()
-        assert not (tmp_dir / live.dvc_file).exists()
 
 
 def test_exp_save_skip_on_env_vars(tmp_dir, monkeypatch, mocker):
@@ -111,4 +124,3 @@ def test_exp_save_skip_on_dvc_repro(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_not_called()
-    assert not (tmp_dir / live.dvc_file).exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -183,6 +183,7 @@ def test_cleanup(tmp_dir, html):
     assert (tmp_dir / "logs" / "some_user_file.txt").is_file()
     assert not (tmp_dir / dvclive.plots_dir / Metric.subfolder).exists()
     assert not (tmp_dir / dvclive.metrics_file).is_file()
+    assert not (tmp_dir / dvclive.dvc_file).is_file()
     assert not (html_path).is_file()
 
 


### PR DESCRIPTION
Slightly more complicated approach to #381.

Summary: write `dvc.yaml` at each call of `live.next_step` or `live.end` with only sections for outputs that exist (for example, skip `params` section in `dvc.yaml` if no params were logged).

Notes on this approach:
1. Everything works so far even when transitioning to pipelines.
2. Could be more flexible when trying to implement things like #371. Not sure how long it will make sense to keep `dvc.yaml` static.