### PR TITLE
live.end: Don't increment `step` value.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -271,8 +271,8 @@ class Live:
         """Saves the given parameter value to yaml"""
         self.log_params({name: val})
 
-    def make_summary(self):
-        if self._step is not None:
+    def make_summary(self, update_step: bool = True):
+        if self._step is not None and update_step:
             self.summary["step"] = self.step
         dump_json(self.summary, self.metrics_file, cls=NumpyEncoder)
 
@@ -296,7 +296,7 @@ class Live:
                 open_file_in_browser(self.report_file)
 
     def end(self):
-        self.make_summary()
+        self.make_summary(update_step=False)
         make_dvcyaml(self)
         if self._studio_url and self._studio_token:
             if "done" not in self._studio_events_to_skip:

--- a/tests/test_fastai.py
+++ b/tests/test_fastai.py
@@ -90,5 +90,5 @@ def test_fast_ai_resume(tmp_dir, data_loader, mocker):
     callback = DVCLiveCallback(resume=True)
     live = callback.live
     spy = mocker.spy(live, "next_step")
-    learn.fit_one_cycle(3, cbs=[callback], start_epoch=live.step - 1)
+    learn.fit_one_cycle(3, cbs=[callback], start_epoch=live.step)
     assert spy.call_count == 1

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -158,7 +158,7 @@ def test_lightning_steps(tmp_dir):
     trainer.fit(model)
 
     history, latest = parse_metrics(dvclive_logger.experiment)
-    assert latest["step"] == 8
+    assert latest["step"] == 7
     assert latest["epoch"] == 1
 
     scalars = os.path.join(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -385,6 +385,18 @@ def test_make_summary_is_called_on_end(tmp_dir):
     assert not log_file.exists()
 
 
+def test_make_summary_on_end_dont_increment_step(tmp_dir):
+    with Live() as live:
+        for i in range(2):
+            live.log_metric("foo", i)
+            live.next_step()
+
+    assert json.loads((tmp_dir / live.metrics_file).read_text()) == {
+        "foo": 1.0,
+        "step": 1,
+    }
+
+
 def test_context_manager(tmp_dir):
     with Live() as live:
         live.summary["foo"] = 1.0


### PR DESCRIPTION
Add `update_step` option to `make_summary`, default `True` to preserve old behavior but set to `False` inside `live.end`.

Closes #389