### PR TITLE
Create signal file whenever DVCLive is running a non-DVC experiment (VS Code)

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -17,6 +17,15 @@ def _dvc_dir(dirname):
     return os.path.join(dirname, ".dvc")
 
 
+def _dvc_exps_run_dir(dirname: str) -> str:
+    return os.path.join(dirname, ".dvc", "tmp", "exps", "run")
+
+
+def _dvclive_only_signal_file(root_dir: str) -> str:
+    dvc_exps_run_dir = _dvc_exps_run_dir(root_dir)
+    return os.path.join(dvc_exps_run_dir, "DVCLIVE_ONLY")
+
+
 def _find_dvc_root(root=None):
     if not root:
         root = os.getcwd()
@@ -36,8 +45,18 @@ def _find_dvc_root(root=None):
     return None
 
 
-def make_checkpoint():
+def _write_file(file: str):
     import builtins
+
+    with builtins.open(file, "w", encoding="utf-8") as fobj:
+        # NOTE: force flushing/writing empty file to disk, otherwise when
+        # run in certain contexts (pytest) file may not actually be written
+        fobj.write("")
+        fobj.flush()
+        os.fsync(fobj.fileno())
+
+
+def make_checkpoint():
     from time import sleep
 
     root_dir = _find_dvc_root()
@@ -46,12 +65,8 @@ def make_checkpoint():
 
     signal_file = os.path.join(root_dir, ".dvc", "tmp", env.DVC_CHECKPOINT)
 
-    with builtins.open(signal_file, "w", encoding="utf-8") as fobj:
-        # NOTE: force flushing/writing empty file to disk, otherwise when
-        # run in certain contexts (pytest) file may not actually be written
-        fobj.write("")
-        fobj.flush()
-        os.fsync(fobj.fileno())
+    _write_file(signal_file)
+
     while os.path.exists(signal_file):
         sleep(_CHECKPOINT_SLEEP)
 
@@ -108,3 +123,33 @@ def make_dvcyaml(live):
     if live._metrics or live._plots or live._images:
         dvcyaml["plots"] = [os.path.relpath(live.plots_dir, live.dir)]
     dump_yaml(dvcyaml, live.dvc_file)
+
+
+def mark_dvclive_only_started():
+    """
+    Signal DVC VS Code extension that
+    an experiment is running in the workspace.
+    """
+    root_dir = _find_dvc_root()
+    if not root_dir:
+        return
+
+    exp_run_dir = _dvc_exps_run_dir(root_dir)
+    os.makedirs(exp_run_dir, exist_ok=True)
+
+    signal_file = _dvclive_only_signal_file(root_dir)
+
+    _write_file(signal_file)
+
+
+def mark_dvclive_only_ended():
+    root_dir = _find_dvc_root()
+    if not root_dir:
+        return
+
+    signal_file = _dvclive_only_signal_file(root_dir)
+
+    if not os.path.exists(signal_file):
+        return
+
+    os.remove(signal_file)

--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -46,13 +46,13 @@ def _find_dvc_root(root=None):
     return None
 
 
-def _write_file(file: str):
+def _write_file(file: str, contents=""):
     import builtins
 
     with builtins.open(file, "w", encoding="utf-8") as fobj:
         # NOTE: force flushing/writing empty file to disk, otherwise when
         # run in certain contexts (pytest) file may not actually be written
-        fobj.write("")
+        fobj.write(str(contents))
         fobj.flush()
         os.fsync(fobj.fileno())
 
@@ -156,7 +156,7 @@ def mark_dvclive_only_started():
 
     signal_file = _dvclive_only_signal_file(root_dir)
 
-    _write_file(signal_file)
+    _write_file(signal_file, os.getpid())
 
 
 def mark_dvclive_only_ended():

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -8,7 +8,14 @@ from typing import Any, Dict, List, Optional, Set, Union
 from ruamel.yaml.representer import RepresenterError
 
 from . import env
-from .dvc import get_dvc_repo, make_checkpoint, make_dvcyaml, random_exp_name
+from .dvc import (
+    get_dvc_repo,
+    make_checkpoint,
+    make_dvcyaml,
+    mark_dvclive_only_ended,
+    mark_dvclive_only_started,
+    random_exp_name,
+)
 from .error import (
     InvalidDataTypeError,
     InvalidParameterTypeError,
@@ -115,6 +122,7 @@ class Live:
                     self._exp_name = random_exp_name(
                         self._dvc_repo, self._baseline_rev
                     )
+                    mark_dvclive_only_started()
 
     def _init_studio(self):
         if not self._dvc_repo:
@@ -314,6 +322,7 @@ class Live:
             self._dvc_repo.experiments.save(
                 name=self._exp_name, include_untracked=self.dir
             )
+            mark_dvclive_only_ended()
 
     def make_checkpoint(self):
         if env2bool(env.DVC_CHECKPOINT):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -443,3 +443,30 @@ def test_create_checkpoint_file(
         assert not native_exists(
             os.path.join(".dvc", "tmp", env.DVC_CHECKPOINT)
         )
+
+
+@pytest.mark.vscode
+@pytest.mark.parametrize("dvc_root", [True, False])
+def test_vscode_dvclive_only_signal_file(tmp_dir, dvc_root, mocker):
+    signal_file = os.path.join(
+        tmp_dir, ".dvc", "tmp", "exps", "run", "DVCLIVE_ONLY"
+    )
+
+    if dvc_root:
+        (tmp_dir / ".dvc").mkdir(parents=True)
+
+    assert not os.path.exists(signal_file)
+
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.index.stages = []
+    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
+        dvclive = Live(save_dvc_exp=True)
+
+    if dvc_root:
+        assert os.path.exists(signal_file)
+    else:
+        assert not os.path.exists(signal_file)
+
+    dvclive.end()
+
+    assert not os.path.exists(signal_file)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -451,6 +451,7 @@ def test_vscode_dvclive_only_signal_file(tmp_dir, dvc_root, mocker):
     signal_file = os.path.join(
         tmp_dir, ".dvc", "tmp", "exps", "run", "DVCLIVE_ONLY"
     )
+    test_pid = 12345
 
     if dvc_root:
         (tmp_dir / ".dvc").mkdir(parents=True)
@@ -459,11 +460,16 @@ def test_vscode_dvclive_only_signal_file(tmp_dir, dvc_root, mocker):
 
     dvc_repo = mocker.MagicMock()
     dvc_repo.index.stages = []
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
+    with mocker.patch(
+        "dvclive.live.get_dvc_repo", return_value=dvc_repo
+    ), mocker.patch("dvclive.live.os.getpid", return_value=test_pid):
         dvclive = Live(save_dvc_exp=True)
 
     if dvc_root:
         assert os.path.exists(signal_file)
+        with open(signal_file, encoding="utf-8") as f:
+            assert f.read() == str(test_pid)
+
     else:
         assert not os.path.exists(signal_file)
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

----

There was a behaviour change shipped in the VS Code extension a few days ago where we no longer auto-select experiments for plotting by default. We (I) changed the behaviour to only auto-select experiments that have been run inside of the current session. Otherwise, we leave the selection up to the user (and/or the previous session). In order to do this I changed the extension's internal mechanics to rely on the `executor` & `status` fields inside of the `exp show` data. These fields are not populated when DVCLive is running outside of the experiment context and using `exp save` to generate the final experiment data (I've looked at the code and can see this would be a difficult change). 

All of that leads to the following behaviour for people being onboarded through the new route of instrumenting their code with DVCLive:

https://user-images.githubusercontent.com/37993418/206624828-7bc29465-f97c-4738-9229-4b6662969d97.mov

I had a long conversation with @dberenbaum this morning (original [here](https://iterativeai.slack.com/archives/C01APS0FHDM/p1670530599513299)) about this subject and we talked about patching the behaviour. I looked into the code (DVC, DVCLive and the extension) and decided that writing a signal file (🤮) was probably the sanest thing to do. Here is what the behaviour will look like after this is shipped and I've made a small update in the extension:


https://user-images.githubusercontent.com/37993418/206626354-663bc4e7-022e-49a4-a2fd-acdf401612c9.mov

LMK what you think.

Note: My Python skills are rusty and I'm not precious about making any required changes to the code. I also had a hard time getting the project set up to run locally (ended up deleting dependencies and tests in order to lint/test what I've changed). Presumably, the difficulty was associated with me being on M1.
