### PR TITLE
log_sklearn_plot: fix .json replacement

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -238,7 +238,7 @@ class Live:
             data = self._plots[name]
         elif kind in SKLEARN_PLOTS and SKLEARN_PLOTS[kind].could_log(val):
             data = SKLEARN_PLOTS[kind](name, self.plots_dir)
-            self._plots[name] = data
+            self._plots[data.name] = data
         else:
             raise InvalidPlotTypeError(name)
 

--- a/src/dvclive/plots/sklearn.py
+++ b/src/dvclive/plots/sklearn.py
@@ -9,10 +9,13 @@ class SKLearnPlot(Data):
     suffixes = [".json"]
     subfolder = "sklearn"
 
+    def __init__(self, name: str, output_folder: str) -> None:
+        super().__init__(name, output_folder)
+        self.name = self.name.replace(".json", "")
+
     @property
     def output_path(self) -> Path:
-        _name = self.name.replace(".json", "")
-        _path = Path(f"{self.output_folder / _name}.json")
+        _path = Path(f"{self.output_folder / self.name}.json")
         _path.parent.mkdir(exist_ok=True, parents=True)
         return _path
 


### PR DESCRIPTION
Currently breaks when using `.json` in the `name` because `live._plots` keeps the suffix.
