### PR TITLE
make_dvcyaml: Skip creation if any existing plot contains live.plots_dir

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -100,6 +100,12 @@ def random_exp_name(dvc_repo, baseline_rev):
 
 
 def make_dvcyaml(live):
+    if live._dvc_repo is not None:
+        abs_plots_dir = os.path.abspath(live.plots_dir)
+        for plot in live._dvc_repo.index.plots:
+            if str(plot.fs_path).startswith(abs_plots_dir):
+                return
+
     dvcyaml = {}
     if live._params:
         dvcyaml["params"] = [os.path.relpath(live.params_file, live.dir)]

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -123,3 +123,17 @@ def test_exp_save_skip_on_dvc_repro(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_not_called()
+
+
+def test_make_dvcyaml_skip_on_plot_definition(tmp_dir, mocker):
+    dvc_repo = mocker.MagicMock()
+    plot = mocker.MagicMock()
+    plot.fs_path = tmp_dir / "dvclive" / "plots" / "metrics" / "foo.tsv"
+    dvc_repo.index.plots = [plot]
+
+    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
+        live = Live()
+        live.log_metric("foo", 1)
+        live.next_step()
+
+    assert not (tmp_dir / live.dvc_file).exists()


### PR DESCRIPTION
Keep writing dvc.yaml to make it possible https://github.com/iterative/dvclive/issues/381#issuecomment-1344387552 but try to avoid collection issues (https://iterativeai.slack.com/archives/CB41NAL8H/p1670467927071269)