### PR TITLE
studio: Fix passing `rev` in `dvc repro` execution.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -99,6 +99,10 @@ class Live:
 
     def _init_dvc(self):
         self._dvc_repo = get_dvc_repo()
+
+        if self._dvc_repo is not None:
+            self._baseline_rev = self._dvc_repo.scm.get_rev()
+
         if os.getenv(env.DVC_EXP_BASELINE_REV, None):
             # `dvc exp` execution
             self._baseline_rev = os.getenv(env.DVC_EXP_BASELINE_REV, "")
@@ -111,7 +115,6 @@ class Live:
                     self._save_dvc_exp = False
                 else:
                     # `DVCLive Only` execution
-                    self._baseline_rev = self._dvc_repo.scm.get_rev()
                     self._exp_name = random_exp_name(
                         self._dvc_repo, self._baseline_rev
                     )

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -140,7 +140,7 @@ def test_exp_save_on_end(tmp_dir, mocker, save):
         )
         assert (tmp_dir / live.dvc_file).exists()
     else:
-        assert live._baseline_rev is None
+        assert live._baseline_rev is not None
         assert live._exp_name is None
         dvc_repo.experiments.save.assert_not_called()
         assert not (tmp_dir / live.dvc_file).exists()
@@ -167,7 +167,7 @@ def test_exp_save_skip_on_dvc_repro(tmp_dir, mocker):
     with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
         live = Live(save_dvc_exp=True)
         assert not live._save_dvc_exp
-        assert live._baseline_rev is None
+        assert live._baseline_rev is not None
         assert live._exp_name is None
         live.end()
 

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -15,7 +15,9 @@ from dvclive.studio import (
 
 
 def test_post_to_studio(tmp_dir, mocker, monkeypatch):
-    mocker.patch("dvclive.live.get_dvc_repo")
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.scm.get_rev.return_value = "current_rev"
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
     mocked_response = mocker.MagicMock()
     mocked_response.status_code = 200
     mocked_post = mocker.patch("requests.post", return_value=mocked_response)
@@ -32,7 +34,7 @@ def test_post_to_studio(tmp_dir, mocker, monkeypatch):
         json={
             "type": "start",
             "repo_url": "STUDIO_REPO_URL",
-            "rev": mocker.ANY,
+            "rev": "current_rev",
             "client": "dvclive",
         },
         headers={
@@ -50,7 +52,7 @@ def test_post_to_studio(tmp_dir, mocker, monkeypatch):
         json={
             "type": "data",
             "repo_url": "STUDIO_REPO_URL",
-            "rev": mocker.ANY,
+            "rev": "current_rev",
             "step": 0,
             "metrics": {live.metrics_file: {"data": {"step": 0, "foo": 1}}},
             "plots": {scalar_path: {"data": [{"step": 0, "foo": 1.0}]}},
@@ -71,7 +73,7 @@ def test_post_to_studio(tmp_dir, mocker, monkeypatch):
         json={
             "type": "data",
             "repo_url": "STUDIO_REPO_URL",
-            "rev": mocker.ANY,
+            "rev": "current_rev",
             "step": 1,
             "metrics": {live.metrics_file: {"data": {"step": 1, "foo": 2}}},
             "plots": {scalar_path: {"data": [{"step": 1, "foo": 2.0}]}},


### PR DESCRIPTION
`dvc repro` execution was not correctly getting `baseline_rev`, breaking Live metrics remote scenario