### PR TITLE
studio: Skip `data` event if no `STUDIO_TOKEN`.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -33,9 +33,11 @@ from .utils import (
 )
 
 try:
+    from dvc_studio_client.env import STUDIO_TOKEN
     from dvc_studio_client.post_live_metrics import post_live_metrics
 except ImportError:
     post_live_metrics = None
+    STUDIO_TOKEN = None
 
 logging.basicConfig()
 logger = logging.getLogger("dvclive")
@@ -149,6 +151,14 @@ class Live:
                 )
 
     def _init_studio(self):
+        if post_live_metrics is not None:
+            if not os.getenv(STUDIO_TOKEN, None):
+                logger.debug("Skipping `studio` report.")
+                self._studio_events_to_skip.add("start")
+                self._studio_events_to_skip.add("data")
+                self._studio_events_to_skip.add("done")
+                return
+
         if not self._dvc_repo:
             logger.debug("`studio` report can't be used without a DVC Repo.")
             self._studio_events_to_skip.add("start")

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -223,3 +223,23 @@ def test_post_to_studio_skip_on_env_var(tmp_dir, mocker, monkeypatch):
         live.next_step()
 
     assert mocked_post.call_count == 0
+
+
+@pytest.mark.studio
+def test_post_to_studio_skip_if_no_token(tmp_dir, mocker, monkeypatch):
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.scm.get_rev.return_value = "f" * 40
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+
+    mocked_post = mocker.patch(
+        "dvclive.live.post_live_metrics", return_value=None
+    )
+
+    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "foo")
+    monkeypatch.setenv(DVC_EXP_NAME, "bar")
+
+    with Live() as live:
+        live.log_metric("foo", 1)
+        live.next_step()
+
+    assert mocked_post.call_count == 0


### PR DESCRIPTION
When `_inside_dvc_exp` (user running `dvc exp run`), we were incorrectly trying to send the `data` event if `STUDIO_TOKEN` wasn't set, logging unnecessary warnings.

