### PR TITLE
report: Add `notebook` mode.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ tests =
     %(plots)s
     %(dvc)s
     %(markdown)s
+    ipython
 dev =
     %(tests)s
     %(all)s

--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -37,6 +37,8 @@ class DVCLiveLogger(Logger):
             self._live_init["dir"] = dir
         self._experiment = experiment
         self._version = run_name
+        # Force Live instantiation
+        self.experiment  # noqa pylint: disable=pointless-statement
 
     @property
     def name(self):

--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -20,6 +20,13 @@ if TYPE_CHECKING:
 # noqa pylint: disable=protected-access
 
 
+BLANK_NOTEBOOK_REPORT = """
+<div style="width: 100%;height: 700px;text-align: center">
+DVCLive Report
+</div>
+"""
+
+
 def get_scalar_renderers(metrics_path):
     renderers = []
     for suffix in Metric.suffixes:
@@ -123,6 +130,12 @@ def make_report(live: "Live"):
 
     if live._report_mode == "html":
         render_html(renderers, live.report_file, refresh_seconds=5)
+    elif live._report_mode == "notebook":
+        from IPython.display import IFrame
+
+        render_html(renderers, live.report_file)
+        if live._report_notebook is not None:
+            live._report_notebook.update(IFrame(live.report_file, "100%", 700))
     elif live._report_mode == "md":
         render_markdown(renderers, live.report_file)
     else:

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from platform import uname
 
+# noqa pylint: disable=unused-import
+
 
 def nested_set(d, keys, value):
     """Set d[keys[0]]...[keys[-1]] to `value`.
@@ -117,9 +119,26 @@ def parse_metrics(live):
 
 
 def matplotlib_installed() -> bool:
-    # noqa pylint: disable=unused-import
     try:
         import matplotlib  # noqa: F401
     except ImportError:
         return False
     return True
+
+
+def inside_notebook() -> bool:
+    try:
+        from google import colab  # noqa: F401
+
+        return True
+    except ImportError:
+        pass
+    try:
+        shell = get_ipython().__class__.__name__  # type: ignore[name-defined]
+    except NameError:
+        return False
+    if shell == "ZMQInteractiveShell":
+        import IPython
+
+        return IPython.__version__ >= "6.0.0"
+    return False


### PR DESCRIPTION
Renders existing HTML report inside an IFrame and updates it on each next_step.

Closes #309

---


https://user-images.githubusercontent.com/12677733/217227396-5ea5f552-bd9c-460a-8ebb-66892a969413.mp4



