### PR TITLE
studio: Include `{live.dvc_file}::` prefix when needed.

### DIFF
--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -38,9 +38,7 @@ def get_studio_updates(live):
     if os.path.isfile(live.dvc_file):
         # Add prefix to match DVC's `repo.plos.show`.
         # See https://github.com/iterative/studio/issues/4981
-        plots = {
-            f"{live.dvc_file}::{name}": plot for name, plot in plots.items()
-        }
+        plots = {f"{live.dvc_file}::{name}": plot for name, plot in plots.items()}
     for name, plot in plots.items():
         datapoints = _get_unsent_datapoints(plot, latest_step)
         plots[name] = _cast_to_numbers(datapoints)

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -35,6 +35,12 @@ def get_studio_updates(live):
     plots, metrics = parse_metrics(live)
     latest_step = live._latest_studio_step
 
+    if os.path.isfile(live.dvc_file):
+        # Add prefix to match DVC's `repo.plos.show`.
+        # See https://github.com/iterative/studio/issues/4981
+        plots = {
+            f"{live.dvc_file}::{name}": plot for name, plot in plots.items()
+        }
     for name, plot in plots.items():
         datapoints = _get_unsent_datapoints(plot, latest_step)
         plots[name] = _cast_to_numbers(datapoints)

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -257,7 +257,6 @@ def test_post_to_studio_include_prefix_if_needed(tmp_dir, mocker, monkeypatch):
     # Create dvclive/dvc.yaml
     live = Live("custom_dir", save_dvc_exp=True)
     live.log_metric("foo", 1)
-    print("NEXT STEP")
     live.next_step()
 
     scalar_path = os.path.join(live.plots_dir, Metric.subfolder, "foo.tsv")


### PR DESCRIPTION
When plots are defined in `{live.dvc_file}`, there was a mismatch between the names returned by `repo.plots.show` and the names sent to the live endpoint.

Closes https://github.com/iterative/studio/issues/4981

--- 

Tested in the repo mentioned in the issue:


https://user-images.githubusercontent.com/12677733/215758399-1c0b87b0-334a-47d7-89f5-4bf0e219e1f2.mov

<img width="1790" alt="Captura de pantalla 2023-01-31 a las 13 23 00" src="https://user-images.githubusercontent.com/12677733/215758761-a173fafc-9bed-4fb3-b54d-0f3370cc0c98.png">
