### PR TITLE
don't remove dvc.yaml file

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -96,7 +96,6 @@ class Live:
             self.metrics_file,
             self.report_file,
             self.params_file,
-            self.dvc_file,
         ):
             if f and os.path.exists(f):
                 os.remove(f)


### PR DESCRIPTION
Until we address https://github.com/iterative/dvclive/issues/381 (needs a major version change), we can stop removing `dvc.yaml` during init. That way, for people who transition to using pipelines, they still keep their `dvc.yaml` from the no-pipeline runs. Should at least partially address https://github.com/iterative/dvclive/issues/435.