### PR TITLE
Shorten names of fields in plots tsv files

### DIFF
--- a/src/dvclive/plots/metric.py
+++ b/src/dvclive/plots/metric.py
@@ -33,7 +33,7 @@ class Metric(Data):
         if kwargs.get("timestamp", False):
             row["timestamp"] = int(time.time() * 1000)
         row["step"] = self.step
-        row[self.name] = val
+        row[os.path.basename(self.name)] = val
 
         existed = self.output_path.exists()
         with open(self.output_path, "a", encoding="utf-8", newline="") as fobj:

--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -11,7 +11,7 @@ from dvc_render.vega import VegaRenderer
 from dvclive.plots import SKLEARN_PLOTS, Image, Metric
 from dvclive.plots.sklearn import SKLearnPlot
 from dvclive.serialize import load_yaml
-from dvclive.utils import parse_scalar_history, parse_tsv
+from dvclive.utils import parse_scalar_history
 
 if TYPE_CHECKING:
     from dvclive import Live

--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -11,7 +11,7 @@ from dvc_render.vega import VegaRenderer
 from dvclive.plots import SKLEARN_PLOTS, Image, Metric
 from dvclive.plots.sklearn import SKLearnPlot
 from dvclive.serialize import load_yaml
-from dvclive.utils import parse_tsv
+from dvclive.utils import parse_scalar_history, parse_tsv
 
 if TYPE_CHECKING:
     from dvclive import Live
@@ -24,12 +24,12 @@ def get_scalar_renderers(metrics_path):
     renderers = []
     for suffix in Metric.suffixes:
         for file in metrics_path.rglob(f"*{suffix}"):
-            data = parse_tsv(file)
-            for row in data:
-                row["rev"] = "workspace"
-
             y = file.relative_to(metrics_path).with_suffix("")
             y = y.as_posix()
+
+            data = parse_scalar_history(metrics_path, file)
+            for row in data:
+                row["rev"] = "workspace"
 
             name = file.relative_to(metrics_path.parent).with_suffix("")
             name = name.as_posix()

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -100,7 +100,7 @@ def standardize_metric_name(metric_name: str, framework: str) -> str:
 def parse_tsv(path):
     with open(path, encoding="utf-8", newline="") as fd:
         reader = csv.DictReader(fd, delimiter="\t")
-        return list(reader)
+        return reader
 
 
 def parse_json(path):
@@ -115,7 +115,13 @@ def parse_metrics(live):
     history = {}
     for suffix in Metric.suffixes:
         for scalar_file in plots_path.rglob(f"*{suffix}"):
-            history[str(scalar_file)] = parse_tsv(scalar_file)
+            history[src(scalar_file)] = []
+            name = str(scalar_file.with_suffix("")).removeprefix(plots_path)
+            short_name = os.path.basename(name)
+            for row in parse_tsv(scalar_file):
+                row[name] = row[short_name]
+                del row[short_name]
+                history[src(scalar_file)].append(row)
     latest = parse_json(live.metrics_file)
     return history, latest
 

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -111,15 +111,12 @@ def parse_metrics(live):
     history = {}
     for suffix in Metric.suffixes:
         for scalar_file in metrics_path.rglob(f"*{suffix}"):
-            history[str(scalar_file)] = parse_scalar_history(metrics_path,
-                                                             scalar_file)
+            history[str(scalar_file)] = parse_scalar_history(metrics_path, scalar_file)
     latest = parse_json(live.metrics_file)
     return history, latest
 
 
 def parse_scalar_history(metrics_path, scalar_file):
-    from .plots import Metric
-
     name = scalar_file.relative_to(metrics_path).with_suffix("")
     short_name = name.name
     name = name.as_posix()

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -100,7 +100,7 @@ def standardize_metric_name(metric_name: str, framework: str) -> str:
 def parse_tsv(path):
     with open(path, encoding="utf-8", newline="") as fd:
         reader = csv.DictReader(fd, delimiter="\t")
-        return reader
+        return list(reader)
 
 
 def parse_json(path):
@@ -111,19 +111,29 @@ def parse_json(path):
 def parse_metrics(live):
     from .plots import Metric
 
-    plots_path = Path(live.plots_dir)
+    metrics_path = Path(live.plots_dir) / Metric.subfolder
     history = {}
     for suffix in Metric.suffixes:
-        for scalar_file in plots_path.rglob(f"*{suffix}"):
-            history[src(scalar_file)] = []
-            name = str(scalar_file.with_suffix("")).removeprefix(plots_path)
-            short_name = os.path.basename(name)
-            for row in parse_tsv(scalar_file):
-                row[name] = row[short_name]
-                del row[short_name]
-                history[src(scalar_file)].append(row)
+        for scalar_file in metrics_path.rglob(f"*{suffix}"):
+            history[str(scalar_file)] = parse_scalar_history(metrics_path,
+                                                             scalar_file)
     latest = parse_json(live.metrics_file)
     return history, latest
+
+
+def parse_scalar_history(metrics_path, scalar_file):
+    from .plots import Metric
+
+    name = scalar_file.relative_to(metrics_path).with_suffix("")
+    short_name = name.name
+    name = name.as_posix()
+    history = []
+    for row in parse_tsv(scalar_file):
+        if name != short_name:
+            row[name] = row[short_name]
+            del row[short_name]
+        history.append(row)
+    return history
 
 
 def matplotlib_installed() -> bool:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,7 @@ from dvclive.error import (
 )
 from dvclive.plots import Metric
 from dvclive.serialize import load_yaml
-from dvclive.utils import parse_metrics
+from dvclive.utils import parse_metrics, parse_tsv
 
 
 def read_history(live, metric):
@@ -148,6 +148,10 @@ def test_nested_logging(tmp_dir):
     assert (out / "train" / "m1.tsv").is_file()
     assert (out / "val" / "val_1" / "m1.tsv").is_file()
     assert (out / "val" / "val_1" / "m2.tsv").is_file()
+
+    assert "m1" in parse_tsv(out / "train" / "m1.tsv")[0]
+    assert "m1" in parse_tsv(out / "val" / "val_1" / "m1.tsv")[0]
+    assert "m2" in parse_tsv(out / "val" / "val_1" / "m2.tsv")[0]
 
     summary = load_yaml(dvclive.metrics_file)
 


### PR DESCRIPTION
This is another breaking change, so it would be good to merge it along with #443, although it doesn't need to block if it's not quick to get merged.

This shortens repetitive plots fields. For example, instead of `results/plots/metrics/train/epoch/acc.tsv: train/epoch/acc`, it becomes `results/plots/metrics/train/epoch/acc.tsv: acc`.