### PR TITLE
`save_dvc_exp` works with existing pipelines/repro

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -119,7 +119,7 @@ class Live:
                 )
         elif self._save_dvc_exp:
             if self._dvc_repo is not None:
-                # `DVCLive Only` execution
+                # `DVCLive Only` or `dvc repro` execution
                 self._exp_name = get_random_exp_name(
                     self._dvc_repo.scm, self._baseline_rev
                 )

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -119,20 +119,11 @@ class Live:
                 )
         elif self._save_dvc_exp:
             if self._dvc_repo is not None:
-                if any(
-                    not stage.is_data_source for stage in self._dvc_repo.index.stages
-                ):
-                    logger.warning(
-                        "Ignoring `_save_dvc_exp` because there is an existing"
-                        " `dvc.yaml` file."
-                    )
-                    self._save_dvc_exp = False
-                else:
-                    # `DVCLive Only` execution
-                    self._exp_name = get_random_exp_name(
-                        self._dvc_repo.scm, self._baseline_rev
-                    )
-                    mark_dvclive_only_started()
+                # `DVCLive Only` execution
+                self._exp_name = get_random_exp_name(
+                    self._dvc_repo.scm, self._baseline_rev
+                )
+                mark_dvclive_only_started()
             else:
                 logger.warning(
                     "Can't save experiment without a DVC Repo."


### PR DESCRIPTION
@daavoo @shcheklein I messed up the release 🤦 . I was so focused on the `dvc.yaml` changes that I forgot we also need to update `save_dvc_exp` to work when there's an existing pipeline.

There's an open question of whether it should work with `dvc repro`. In the interest of being simple and explicit, I went with saving an experiment even during `dvc repro`. In other words, the only time saving an experiment gets skipped is inside `dvc exp run`.