### PR TITLE
metrics: preserve the name stored in the `.tsv`.

### DIFF
--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -11,7 +11,7 @@ from dvc_render.vega import VegaRenderer
 from dvclive.plots import SKLEARN_PLOTS, Image, Metric
 from dvclive.plots.sklearn import SKLearnPlot
 from dvclive.serialize import load_yaml
-from dvclive.utils import parse_scalar_history
+from dvclive.utils import parse_tsv
 
 if TYPE_CHECKING:
     from dvclive import Live
@@ -24,10 +24,7 @@ def get_scalar_renderers(metrics_path):
     renderers = []
     for suffix in Metric.suffixes:
         for file in metrics_path.rglob(f"*{suffix}"):
-            y = file.relative_to(metrics_path).with_suffix("")
-            y = y.as_posix()
-
-            data = parse_scalar_history(metrics_path, file)
+            data = parse_tsv(file)
             for row in data:
                 row["rev"] = "workspace"
 
@@ -35,7 +32,7 @@ def get_scalar_renderers(metrics_path):
             name = name.as_posix()
             name = name.replace(metrics_path.name, "static")
 
-            properties = {"x": "step", "y": y}
+            properties = {"x": "step", "y": file.stem}
             renderers.append(VegaRenderer(data, name, **properties))
     return renderers
 

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -111,22 +111,9 @@ def parse_metrics(live):
     history = {}
     for suffix in Metric.suffixes:
         for scalar_file in metrics_path.rglob(f"*{suffix}"):
-            history[str(scalar_file)] = parse_scalar_history(metrics_path, scalar_file)
+            history[str(scalar_file)] = parse_tsv(scalar_file)
     latest = parse_json(live.metrics_file)
     return history, latest
-
-
-def parse_scalar_history(metrics_path, scalar_file):
-    name = scalar_file.relative_to(metrics_path).with_suffix("")
-    short_name = name.name
-    name = name.as_posix()
-    history = []
-    for row in parse_tsv(scalar_file):
-        if name != short_name:
-            row[name] = row[short_name]
-            del row[short_name]
-        history.append(row)
-    return history
 
 
 def matplotlib_installed() -> bool:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -45,17 +45,17 @@ def test_get_renderers(tmp_dir, mocker):
     assert len(scalar_renderers) == 1
     assert scalar_renderers[0].datapoints == [
         {
-            "foo/bar": "0",
+            "bar": "0",
             "rev": "workspace",
             "step": "0",
         },
         {
-            "foo/bar": "1",
+            "bar": "1",
             "rev": "workspace",
             "step": "1",
         },
     ]
-    assert scalar_renderers[0].properties["y"] == "foo/bar"
+    assert scalar_renderers[0].properties["y"] == "bar"
     assert scalar_renderers[0].name == "static/foo/bar"
 
     metrics_renderer = get_metrics_renderers(live.metrics_file)[0]

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -285,3 +285,46 @@ def test_post_to_studio_include_prefix_if_needed(tmp_dir, mocker, monkeypatch):
         },
         timeout=5,
     )
+
+
+def test_post_to_studio_shorten_names(tmp_dir, mocker, monkeypatch):
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.scm.get_rev.return_value = "f" * 40
+    dvc_repo.index.stages = []
+    dvc_repo.scm.get_ref.return_value = None
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+
+    mocked_response = mocker.MagicMock()
+    mocked_response.status_code = 200
+    mocked_post = mocker.patch("requests.post", return_value=mocked_response)
+
+    monkeypatch.setenv(STUDIO_ENDPOINT, "https://0.0.0.0")
+    monkeypatch.setenv(STUDIO_REPO_URL, "STUDIO_REPO_URL")
+    monkeypatch.setenv(STUDIO_TOKEN, "STUDIO_TOKEN")
+
+    live = Live()
+    live.log_metric("eval/loss", 1)
+    live.next_step()
+
+    scalar_path = os.path.join(live.plots_dir, Metric.subfolder, "eval", "loss.tsv")
+    scalar_name = scalar_path
+    mocked_post.assert_called_with(
+        "https://0.0.0.0",
+        json={
+            "type": "data",
+            "repo_url": "STUDIO_REPO_URL",
+            "baseline_sha": "f" * 40,
+            "name": live._exp_name,
+            "step": 0,
+            "metrics": {live.metrics_file: {"data": {"step": 0, "eval": {"loss": 1}}}},
+            "plots": {
+                f"{live.dvc_file}::{scalar_name}": {"data": [{"step": 0, "loss": 1.0}]}
+            },
+            "client": "dvclive",
+        },
+        headers={
+            "Authorization": "token STUDIO_TOKEN",
+            "Content-type": "application/json",
+        },
+        timeout=5,
+    )


### PR DESCRIPTION
Closes #449
