### PR TITLE
Introduce  `dvcyaml: bool = True`  kwarg for DVCLiveLogger

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ tests =
     pylint==2.15.0
     pylint-plugin-utils>=0.6
     mypy==0.981
+    py==1.11.0
     %(image)s
     %(plots)s
     %(dvc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ tests =
     pylint==2.15.0
     pylint-plugin-utils>=0.6
     mypy==0.981
-    py==1.11.0
     %(image)s
     %(plots)s
     %(dvc)s

--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -23,6 +23,7 @@ class DVCLiveLogger(Logger):
         resume: bool = False,
         report: Optional[str] = "auto",
         save_dvc_exp: bool = False,
+        dvcyaml: bool = True,
     ):
 
         super().__init__()
@@ -31,6 +32,7 @@ class DVCLiveLogger(Logger):
             "resume": resume,
             "report": report,
             "save_dvc_exp": save_dvc_exp,
+            "dvcyaml": dvcyaml,
         }
         if dir is not None:
             self._live_init["dir"] = dir

--- a/tests/test_frameworks/test_lightning.py
+++ b/tests/test_frameworks/test_lightning.py
@@ -137,7 +137,7 @@ def test_lightning_default_dir(tmp_dir):
 def test_lightning_kwargs(tmp_dir):
     model = LitXOR()
     # Handle kwargs passed to Live.
-    dvclive_logger = DVCLiveLogger(dir="dir", report="md")
+    dvclive_logger = DVCLiveLogger(dir="dir", report="md", dvcyaml=False)
     trainer = Trainer(
         logger=dvclive_logger,
         max_epochs=2,
@@ -148,6 +148,7 @@ def test_lightning_kwargs(tmp_dir):
 
     assert os.path.exists("dir")
     assert os.path.exists("dir/report.md")
+    assert not os.path.exists("dir/dvc.yaml")
 
 
 def test_lightning_steps(tmp_dir):


### PR DESCRIPTION
This PR introduces a the `dvcyaml: bool = True,` kwarg for the DVCLiveLogger for Pytorch Lightning following the addition of the same kwarg to the Live logger class in [PR 443](https://github.com/iterative/dvclive/pull/443).  Tests were updated accordingly 

I did not update documentation because it is already out of date.  

This PR also adds `py` as a dependency since it is no longer an explicit dependency of pytest. 

* [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. https://github.com/iterative/dvc.org/issues/4294

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
