### PR TITLE
report: Use `HTML` instead of `IFrame` inside Google Colab.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir=
     =src
 packages = find:
 install_requires=
-    dvc_render[table]>=0.0.12
+    dvc_render[table]>=0.1.2
     ruamel.yaml>=0.17.11
     dvc-studio-client>=0.4.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires=
 
 [options.extras_require]
 dvc =
-    dvc>=2.38.1
+    dvc>=2.45.0
 image =
     numpy
     pillow

--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -11,7 +11,7 @@ from dvc_render.vega import VegaRenderer
 from dvclive.plots import SKLEARN_PLOTS, Image, Metric
 from dvclive.plots.sklearn import SKLearnPlot
 from dvclive.serialize import load_yaml
-from dvclive.utils import parse_tsv
+from dvclive.utils import inside_colab, parse_tsv
 
 if TYPE_CHECKING:
     from dvclive import Live
@@ -25,6 +25,25 @@ BLANK_NOTEBOOK_REPORT = """
 DVCLive Report
 </div>
 """
+
+COLAB_HTML = """<!DOCTYPE html>
+<html>
+<head>
+    {refresh_tag}
+    <title>DVC Plot</title>
+    {scripts}
+    <style>
+        table {
+            border-spacing: 15px;
+        }
+    </style>
+</head>
+<body>
+    <div style="width: 100%;height: 700px>
+        {plot_divs}
+    </div>
+</body>
+</html>"""
 
 
 def get_scalar_renderers(metrics_path):
@@ -131,11 +150,20 @@ def make_report(live: "Live"):
     if live._report_mode == "html":
         render_html(renderers, live.report_file, refresh_seconds=5)
     elif live._report_mode == "notebook":
-        from IPython.display import IFrame
+        from IPython.display import HTML, IFrame
 
-        render_html(renderers, live.report_file)
+        render_html(
+            renderers,
+            live.report_file,
+            # Use custom template to limit the size of the display
+            html_template=COLAB_HTML if inside_colab() else None,
+        )
         if live._report_notebook is not None:
-            live._report_notebook.update(IFrame(live.report_file, "100%", 700))
+            if inside_colab():
+                new_report = HTML(live.report_file)
+            else:
+                new_report = IFrame(live.report_file, "100%", 700)
+            live._report_notebook.update(new_report)
     elif live._report_mode == "md":
         render_markdown(renderers, live.report_file)
     else:

--- a/src/dvclive/report.py
+++ b/src/dvclive/report.py
@@ -160,9 +160,11 @@ def make_report(live: "Live"):
         )
         if live._report_notebook is not None:
             if inside_colab():
-                new_report = HTML(live.report_file)
+                new_report = HTML(live.report_file)  # type: ignore [assignment]
             else:
-                new_report = IFrame(live.report_file, "100%", 700)
+                new_report = IFrame(  # type: ignore [assignment]
+                    live.report_file, "100%", 700
+                )
             live._report_notebook.update(new_report)
     elif live._report_mode == "md":
         render_markdown(renderers, live.report_file)

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -126,17 +126,24 @@ def matplotlib_installed() -> bool:
     return True
 
 
-def inside_notebook() -> bool:
+def inside_colab() -> bool:
     try:
         from google import colab  # noqa: F401
 
         return True
     except ImportError:
-        pass
+        return False
+
+
+def inside_notebook() -> bool:
+    if inside_colab():
+        return True
+
     try:
         shell = get_ipython().__class__.__name__  # type: ignore[name-defined]
     except NameError:
         return False
+
     if shell == "ZMQInteractiveShell":
         import IPython
 


### PR DESCRIPTION
Requires https://github.com/iterative/dvc-render/pull/118

Closes #460 


![dvclive-notebook](https://user-images.githubusercontent.com/12677733/218449002-d7023349-44ba-408f-9aab-be8ac6e85557.gif)


