### PR TITLE
Implement log_artifact method for live

### DIFF
--- a/src/dvclive/error.py
+++ b/src/dvclive/error.py
@@ -27,3 +27,12 @@ class InvalidParameterTypeError(DvcLiveError):
     def __init__(self, val: Any):
         self.val = val
         super().__init__(f"Parameter type {type(val)} is not supported.")
+
+
+class DuplicateArtifactError(DvcLiveError):
+    def __init__(self, name):
+        self.name = name
+        super().__init__(
+            f"File '{name}' had already been a output of another "
+            "dvc stage, can't add it as a artifact of dvclive."
+        )

--- a/src/dvclive/error.py
+++ b/src/dvclive/error.py
@@ -27,12 +27,3 @@ class InvalidParameterTypeError(DvcLiveError):
     def __init__(self, val: Any):
         self.val = val
         super().__init__(f"Parameter type {type(val)} is not supported.")
-
-
-class DuplicateArtifactError(DvcLiveError):
-    def __init__(self, name):
-        self.name = name
-        super().__init__(
-            f"File '{name}' had already been a output of another "
-            "dvc stage, can't add it as a artifact of dvclive."
-        )

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -314,7 +314,7 @@ class Live:
         if self._dvc_repo is not None:
             try:
                 stage = self._dvc_repo.add(path)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 logger.warning(f"Failed to dvc add {path}: {e}")
                 return
 

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -399,8 +399,8 @@ class Live:
 
             try:
                 self._experiment_rev = self._dvc_repo.experiments.save(
-                    name=self._exp_name, 
-                    include_untracked=self._include_untracked, 
+                    name=self._exp_name,
+                    include_untracked=self._include_untracked,
                     force=True,
                 )
             except DvcException as e:

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -57,7 +57,7 @@ class Live:
         self._images: Dict[str, Any] = {}
         self._params: Dict[str, Any] = {}
         self._plots: Dict[str, Any] = {}
-        self._outs: Set[str] = set()
+        self._outs: Set[StrPath] = set()
         self._inside_with = False
         self._dvcyaml = dvcyaml
 
@@ -295,18 +295,11 @@ class Live:
         self._dump_params()
         logger.debug(f"Logged {params} parameters to {self.params_file}")
 
-    def log_param(
-        self,
-        name: str,
-        val: ParamLike,
-    ):
+    def log_param(self, name: str, val: ParamLike):
         """Saves the given parameter value to yaml"""
         self.log_params({name: val})
 
-    def log_artifact(
-        self,
-        path: StrPath,
-    ):
+    def log_artifact(self, path: StrPath):
         """Tracks a local file or directory with DVC"""
         if not isinstance(path, (str, Path)):
             raise InvalidDataTypeError(path, type(path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def mocked_dvc_repo(mocker):
 
 
 @pytest.fixture
-def dvc_repo(tmp_dir):
+def dvc_repo(tmp_dir):  # pylint: disable=redefined-outer-name
     from dvc.repo import Repo
     from scmrepo.git import Git
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,27 @@ def tmp_dir(tmp_path, monkeypatch):
     yield tmp_path
 
 
+@pytest.fixture
+def mocked_dvc_repo(mocker):
+    _dvc_repo = mocker.MagicMock()
+    _dvc_repo.index.stages = []
+    _dvc_repo.scm.get_rev.return_value = "current_rev"
+    _dvc_repo.scm.get_ref.return_value = None
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=_dvc_repo)
+    return _dvc_repo
+
+
+@pytest.fixture
+def dvc_repo(tmp_dir):
+    from dvc.repo import Repo
+    from scmrepo.git import Git
+
+    Git.init(tmp_dir)
+    repo = Repo.init(tmp_dir)
+    repo.scm.add_commit(".", "init")
+    return repo
+
+
 @pytest.fixture(autouse=True)
 def capture_wrap():
     # https://github.com/pytest-dev/pytest/issues/5502#issuecomment-678368525

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -1,4 +1,6 @@
 # pylint: disable=unused-argument,protected-access
+from pathlib import Path
+
 import pytest
 from dvc.repo import Repo
 from PIL import Image
@@ -90,14 +92,21 @@ def test_exp_save_on_end(tmp_dir, mocker, save):
     dvc_repo.index.stages = []
     dvc_repo.scm.get_rev.return_value = "current_rev"
     dvc_repo.scm.get_ref.return_value = None
+    (tmp_dir / "data").write_text("data")
     with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
         live = Live(save_dvc_exp=save)
+        live.log_artifact("data")
         live.end()
     if save:
         assert live._baseline_rev is not None
         assert live._exp_name != "dvclive-exp"
+        dvcfile = dvc_repo.add()[0].addressing
+        assert dvcfile.exists()
+        gitignore = str(Path(dvcfile).parent / ".gitignore")
         dvc_repo.experiments.save.assert_called_with(
-            name=live._exp_name, include_untracked=live.dir, force=True
+            name=live._exp_name,
+            include_untracked=[live.dir, dvcfile, gitignore],
+            force=True,
         )
     else:
         assert live._baseline_rev is not None
@@ -134,7 +143,7 @@ def test_exp_save_run_on_dvc_repro(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_called_with(
-        name=live._exp_name, include_untracked=live.dir, force=True
+        name=live._exp_name, include_untracked=[live.dir], force=True
     )
 
 
@@ -181,5 +190,5 @@ def test_exp_save_with_dvc_files(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_called_with(
-        name=live._exp_name, include_untracked=live.dir, force=True
+        name=live._exp_name, include_untracked=[live.dir], force=True
     )

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -1,0 +1,47 @@
+# pylint: disable=unused-argument,protected-access
+from dvclive import Live
+
+
+def test_log_artifact(tmp_dir, dvc_repo):
+    data = tmp_dir / "data"
+    data.touch()
+    with Live() as live:
+        live.log_artifact("data")
+    assert data.with_suffix(".dvc").exists()
+
+
+def test_log_artifact_on_existing_dvc_file(tmp_dir, dvc_repo):
+    data = tmp_dir / "data"
+    data.write_text("foo")
+    with Live() as live:
+        live.log_artifact("data")
+
+    prev_content = data.with_suffix(".dvc").read_text()
+
+    with Live() as live:
+        data.write_text("bar")
+        live.log_artifact("data")
+
+    assert data.with_suffix(".dvc").read_text() != prev_content
+
+
+def test_log_artifact_twice(tmp_dir, dvc_repo):
+    data = tmp_dir / "data"
+    with Live() as live:
+        for i in range(2):
+            data.write_text(str(i))
+            live.log_artifact("data")
+    assert data.with_suffix(".dvc").exists()
+
+
+def test_log_artifact_with_save_dvc_exp(tmp_dir, mocker, mocked_dvc_repo):
+    stage = mocker.MagicMock()
+    stage.addressing = "data"
+    mocked_dvc_repo.add.return_value = [stage]
+    with Live(save_dvc_exp=True) as live:
+        live.log_artifact("data")
+    mocked_dvc_repo.experiments.save.assert_called_with(
+        name=live._exp_name,
+        include_untracked=[live.dir, "data", ".gitignore"],
+        force=True,
+    )


### PR DESCRIPTION
fix: #378

---

```python
# train.py
import time
from pathlib import Path

from dvclive import Live

Path("data").write_text(str(time.time()))
with Live(save_dvc_exp=True) as live:
    live.log_artifact("data")
```

```console
$ git init
$ dvc init
$ git add train.py
$ git commit -m "init"
$ python train.py
$ git show 6d1a79f
commit 6d1a79fa891e3582a6a9ef93f4e826e5eee5bbe4 (refs/exps/ad/10dbdb6aa0c13b73f48ed8416a65dd57d94899/duddy-yews)
Author: David de la Iglesia Castro <daviddelaiglesiacastro@gmail.com>
Date:   Mon Feb 20 15:23:14 2023 +0100

    dvc: commit experiment duddy-yews

diff --git a/.gitignore b/.gitignore
new file mode 100644
index 0000000..3af0ccb
--- /dev/null
+++ b/.gitignore
@@ -0,0 +1 @@
+/data
diff --git a/data.dvc b/data.dvc
new file mode 100644
index 0000000..3088b76
--- /dev/null
+++ b/data.dvc
@@ -0,0 +1,4 @@
+outs:
+- md5: 11d1fcb11076f6c57252cc495d65fb9a
+  size: 17
+  path: data
```

