### PR TITLE
prevent calling live.end if exception raised

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -501,3 +501,11 @@ def test_make_dvcyaml(tmp_dir, dvcyaml):
     dvcyaml_path = tmp_dir / dvclive.dir / "dvc.yaml"
 
     assert dvcyaml_path.is_file()
+
+
+def test_exception(tmp_dir):
+    with pytest.raises(KeyboardInterrupt):
+        with Live() as live:
+            live.summary["foo"] = 1.0
+            raise KeyboardInterrupt
+    assert not (tmp_dir / live.metrics_file).exists()


### PR DESCRIPTION
This will prevent `live.end` from being called in the event of an exception.

This doesn't solve the problem of showing different completion statuses. For now, we only have a binary choice of whether an experiment is running or completed. This PR makes it so that we will continue to show an experiment in running status when interrupted by an exception. This isn't great, but I think it's more expected than showing it as successfully completed.

Edit: I also think it's probably good practice to abort the rest of `live.end` in the case of unhandled exceptions.