### PR TITLE
live: Ignore `DvcException` in `save_dvc_exp`.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -393,10 +393,16 @@ class Live:
             and not self._inside_dvc_exp
             and self._save_dvc_exp
         ):
-            self._experiment_rev = self._dvc_repo.experiments.save(
-                name=self._exp_name, include_untracked=self.dir, force=True
-            )
-            mark_dvclive_only_ended()
+            from dvc.exceptions import DvcException
+
+            try:
+                self._experiment_rev = self._dvc_repo.experiments.save(
+                    name=self._exp_name, include_untracked=self.dir, force=True
+                )
+            except DvcException as e:
+                logger.warning(f"Failed to save experiment:\n{e}")
+            finally:
+                mark_dvclive_only_ended()
 
     def make_checkpoint(self):
         if env2bool(env.DVC_CHECKPOINT):

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -183,3 +183,17 @@ def test_exp_save_with_dvc_files(tmp_dir, mocker):
     dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name, include_untracked=live.dir, force=True
     )
+
+
+def test_exp_save_dvcexception_is_ignored(tmp_dir, mocker):
+    from dvc.exceptions import DvcException
+
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.index.stages = []
+    dvc_repo.scm.get_rev.return_value = "current_rev"
+    dvc_repo.scm.get_ref.return_value = None
+    dvc_repo.experiments.save.side_effect = DvcException("foo")
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+
+    with Live(save_dvc_exp=True):
+        pass


### PR DESCRIPTION
Closes #466
