### PR TITLE
studio: Don't skip data event if `_inside_dvc_exp`.

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -73,14 +73,19 @@ def make_checkpoint():
         sleep(_CHECKPOINT_SLEEP)
 
 
-def get_dvc_repo():
+def dvc_api_available() -> bool:
     # noqa pylint: disable=unused-import
     try:
-        from dvc.exceptions import NotDvcRepoError
-        from dvc.repo import Repo
-        from dvc.scm import SCMError
+        import dvc  # noqa: F401
     except ImportError:
-        return None
+        return False
+    return True
+
+
+def get_dvc_repo():
+    from dvc.exceptions import NotDvcRepoError
+    from dvc.repo import Repo
+    from dvc.scm import SCMError
 
     try:
         return Repo()

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -146,7 +146,7 @@ class Live:
                 self._studio_events_to_skip.add("done")
                 return
 
-        if not self._dvc_repo:
+        if not (self._dvc_repo or self._inside_dvc_exp):
             logger.debug("`studio` report can't be used without a DVC Repo.")
             self._studio_events_to_skip.add("start")
             self._studio_events_to_skip.add("data")

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -5,10 +5,13 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 
+from dvc_studio_client.env import STUDIO_TOKEN
+from dvc_studio_client.post_live_metrics import post_live_metrics
 from ruamel.yaml.representer import RepresenterError
 
 from . import env
 from .dvc import (
+    dvc_api_available,
     get_dvc_repo,
     get_random_exp_name,
     make_checkpoint,
@@ -28,13 +31,6 @@ from .utils import (
     nested_update,
     open_file_in_browser,
 )
-
-try:
-    from dvc_studio_client.env import STUDIO_TOKEN
-    from dvc_studio_client.post_live_metrics import post_live_metrics
-except ImportError:
-    post_live_metrics = None
-    STUDIO_TOKEN = None
 
 logging.basicConfig()
 logger = logging.getLogger("dvclive")
@@ -110,11 +106,6 @@ class Live:
                 os.remove(f)
 
     def _init_dvc(self):
-        self._dvc_repo = get_dvc_repo()
-
-        if self._dvc_repo is not None:
-            self._baseline_rev = self._dvc_repo.scm.get_rev()
-
         if os.getenv(env.DVC_EXP_BASELINE_REV, None):
             # `dvc exp` execution
             self._baseline_rev = os.getenv(env.DVC_EXP_BASELINE_REV, "")
@@ -124,50 +115,56 @@ class Live:
                 logger.warning(
                     "Ignoring `_save_dvc_exp` because `dvc exp run` is running"
                 )
-        elif self._save_dvc_exp:
-            if self._dvc_repo is not None:
-                # `DVCLive Only` or `dvc repro` execution
-                self._exp_name = get_random_exp_name(
-                    self._dvc_repo.scm, self._baseline_rev
-                )
-                mark_dvclive_only_started()
-            else:
+                self._save_dvc_exp = False
+            return
+
+        self._dvc_repo = get_dvc_repo()
+        if self._dvc_repo is None:
+            if self._save_dvc_exp:
+                if not dvc_api_available():
+                    logger.warning(
+                        "Can't save experiment without the DVC Python API."
+                        "\nYou can install it by calling `pip install dvc`."
+                    )
                 logger.warning(
                     "Can't save experiment without a DVC Repo."
                     "\nYou can create a DVC Repo by calling `dvc init`."
                 )
+                self._save_dvc_exp = False
+            return
+
+        self._baseline_rev = self._dvc_repo.scm.get_rev()
+        if self._save_dvc_exp:
+            self._exp_name = get_random_exp_name(self._dvc_repo.scm, self._baseline_rev)
+            mark_dvclive_only_started()
 
     def _init_studio(self):
-        if post_live_metrics is not None:
-            if not os.getenv(STUDIO_TOKEN, None):
-                logger.debug("Skipping `studio` report.")
-                self._studio_events_to_skip.add("start")
-                self._studio_events_to_skip.add("data")
-                self._studio_events_to_skip.add("done")
-                return
-
-        if not (self._dvc_repo or self._inside_dvc_exp):
-            logger.debug("`studio` report can't be used without a DVC Repo.")
+        if not os.getenv(STUDIO_TOKEN, None):
+            logger.debug("Missing env var `STUDIO_TOKEN`, skipping `studio` report.")
             self._studio_events_to_skip.add("start")
             self._studio_events_to_skip.add("data")
             self._studio_events_to_skip.add("done")
-            return
-
-        if self._inside_dvc_exp:
+        elif self._inside_dvc_exp:
             logger.debug("Skipping `studio` report `start` and `done` events.")
             self._studio_events_to_skip.add("start")
             self._studio_events_to_skip.add("done")
+        elif self._dvc_repo is None:
+            if not dvc_api_available():
+                logger.warning(
+                    "Can't send updates to Studio without the DVC Python API."
+                    "\nYou can install it by calling `pip install dvc`."
+                )
+            logger.warning(
+                "Can't send updates to Studio without a DVC Repo."
+                "\nYou can create a DVC Repo by calling `dvc init`."
+            )
+            self._studio_events_to_skip.add("start")
+            self._studio_events_to_skip.add("data")
+            self._studio_events_to_skip.add("done")
         else:
-            response = False
-            if post_live_metrics is not None:
-                response = post_live_metrics(
-                    "start", self._baseline_rev, self._exp_name, "dvclive"
-                )
-            else:
-                logger.debug(
-                    "`dvc_studio_client` is not installed.\n"
-                    "You can install it with `pip install dvc-studio-client`."
-                )
+            response = post_live_metrics(
+                "start", self._baseline_rev, self._exp_name, "dvclive"
+            )
             if not response:
                 logger.debug(
                     "`studio` report `start` event failed. "
@@ -384,15 +381,10 @@ class Live:
                 logger.warning("`post_to_studio` `done` event failed.")
             self._studio_events_to_skip.add("done")
             self._studio_events_to_skip.add("data")
-
         else:
             self.make_report()
 
-        if (
-            self._dvc_repo is not None
-            and not self._inside_dvc_exp
-            and self._save_dvc_exp
-        ):
+        if self._save_dvc_exp:
             from dvc.exceptions import DvcException
 
             try:

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -197,3 +197,9 @@ def test_exp_save_dvcexception_is_ignored(tmp_dir, mocker):
 
     with Live(save_dvc_exp=True):
         pass
+
+
+def test_exp_save_skipped_if_not_dvc_api_available(tmp_dir, mocker):
+    mocker.patch("dvclive.live.dvc_api_available", return_value=False)
+    live = Live(save_dvc_exp=True)
+    assert not live._save_dvc_exp

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -215,14 +215,13 @@ def test_post_to_studio_skip_on_env_var(tmp_dir, mocker, monkeypatch):
     monkeypatch.setenv(STUDIO_REPO_URL, "STUDIO_REPO_URL")
     monkeypatch.setenv(STUDIO_TOKEN, "STUDIO_TOKEN")
 
-    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "foo")
+    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "f" * 40)
     monkeypatch.setenv(DVC_EXP_NAME, "bar")
 
     with Live() as live:
         live.log_metric("foo", 1)
-        live.next_step()
 
-    assert mocked_post.call_count == 0
+    assert mocked_post.call_count == 1
 
 
 @pytest.mark.studio
@@ -233,7 +232,7 @@ def test_post_to_studio_skip_if_no_token(tmp_dir, mocker, monkeypatch):
 
     mocked_post = mocker.patch("dvclive.live.post_live_metrics", return_value=None)
 
-    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "foo")
+    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "f" * 40)
     monkeypatch.setenv(DVC_EXP_NAME, "bar")
 
     with Live() as live:
@@ -328,3 +327,23 @@ def test_post_to_studio_shorten_names(tmp_dir, mocker, monkeypatch):
         },
         timeout=5,
     )
+
+
+@pytest.mark.studio
+def test_post_to_studio_inside_dvc_exp(tmp_dir, mocker, monkeypatch):
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=None)
+
+    valid_response = mocker.MagicMock()
+    valid_response.status_code = 200
+    mocked_post = mocker.patch("requests.post", return_value=valid_response)
+    monkeypatch.setenv(STUDIO_ENDPOINT, "https://0.0.0.0")
+    monkeypatch.setenv(STUDIO_REPO_URL, "STUDIO_REPO_URL")
+    monkeypatch.setenv(STUDIO_TOKEN, "STUDIO_TOKEN")
+
+    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "f" * 40)
+    monkeypatch.setenv(DVC_EXP_NAME, "bar")
+
+    with Live() as live:
+        live.log_metric("foo", 1)
+
+    assert mocked_post.call_count == 1


### PR DESCRIPTION
Workaround #397 for live experiments with `dvc exp run`.

Closes https://github.com/iterative/dvclive/issues/473

Allows to send `data` updates when running inside `dvc exp run` and DVC is not available as a Python library.