### PR TITLE
Add step to plots config

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -97,8 +97,9 @@ def make_dvcyaml(live):
     plots = []
     plots_path = Path(live.plots_dir)
     if live._metrics:
-        metrics_path = (plots_path / Metric.subfolder).relative_to(live.dir)
-        plots.append(metrics_path.as_posix())
+        metrics_path = (plots_path / Metric.subfolder).relative_to(live.dir).as_posix()
+        metrics_config = {metrics_path: {"x": "step"}}
+        plots.append(metrics_config)
     if live._images:
         images_path = (plots_path / Image.subfolder).relative_to(live.dir)
         plots.append(images_path.as_posix())

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -41,7 +41,7 @@ def test_make_dvcyaml_metrics(tmp_dir):
 
     assert load_yaml(live.dvc_file) == {
         "metrics": ["metrics.json"],
-        "plots": ["plots/metrics"],
+        "plots": [{"plots/metrics": {"x": "step"}}],
     }
 
 
@@ -58,7 +58,7 @@ def test_make_dvcyaml_all_plots(tmp_dir):
         "metrics": ["metrics.json"],
         "params": ["params.yaml"],
         "plots": [
-            "plots/metrics",
+            {"plots/metrics": {"x": "step"}},
             "plots/images",
             {
                 "plots/sklearn/confusion_matrix.json": {


### PR DESCRIPTION
Plots in `dvclive/plots/metrics` do not use the `step` value stored in the tsv but instead infer a step value that's a simple counter of the row numbers. This PR configures those plots to use the `step` value from the tsv as the `x` axis.

Example using the lightning callback, which logs every 50 train steps by default:

Before this PR:

![visualization(37)](https://user-images.githubusercontent.com/2308172/222255930-76ac26c7-1e56-442c-bd5c-bb26bfc03708.png)


After this PR:

![visualization(36)](https://user-images.githubusercontent.com/2308172/222255956-f3498a32-ac3b-4ee0-979e-0d634c5d4a6b.png)

