### PR TITLE
lightning: call next step per epoch

### DIFF
--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -81,15 +81,16 @@ class DVCLiveLogger(Logger):
         ), "experiment tried to log from global_rank != 0"
 
         self.experiment.step = step
-        epoch = False
+        step = False
         for metric_name, metric_val in metrics.items():
             if is_tensor(metric_val):
                 metric_val = metric_val.cpu().detach().item()
-            if metric_name.endswith("_epoch"):
-                epoch = True
+            if metric_name.endswith("_step"):
+                step = True
             metric_name = standardize_metric_name(metric_name, __name__)
             self.experiment.log_metric(name=metric_name, val=metric_val)
-        if epoch:
+        # Only call next_step for epoch-level metrics
+        if not step:
             self.experiment.next_step()
 
     @rank_zero_only

--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -81,12 +81,16 @@ class DVCLiveLogger(Logger):
         ), "experiment tried to log from global_rank != 0"
 
         self.experiment.step = step
+        epoch = False
         for metric_name, metric_val in metrics.items():
             if is_tensor(metric_val):
                 metric_val = metric_val.cpu().detach().item()
+            if metric_name.endswith("_epoch"):
+                epoch = True
             metric_name = standardize_metric_name(metric_name, __name__)
             self.experiment.log_metric(name=metric_name, val=metric_val)
-        self.experiment.next_step()
+        if epoch:
+            self.experiment.next_step()
 
     @rank_zero_only
     def finalize(self, status: str) -> None:

--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -39,6 +39,8 @@ class DVCLiveLogger(Logger):
         self._version = run_name
         # Force Live instantiation
         self.experiment  # noqa pylint: disable=pointless-statement
+        # Track whether all metrics are step-level
+        self._step_only = True
 
     @property
     def name(self):
@@ -80,19 +82,27 @@ class DVCLiveLogger(Logger):
             rank_zero_only.rank == 0  # type: ignore
         ), "experiment tried to log from global_rank != 0"
 
-        self.experiment.step = step
-        step = False
+        if self.experiment.step != step:
+            # don't call next_step if only "_step" metrics were logged
+            if not self._step_only:
+                self.experiment.next_step()
+                self._step_only = True
+            self.experiment.step = step
+
+        step_metrics = False
         for metric_name, metric_val in metrics.items():
             if is_tensor(metric_val):
                 metric_val = metric_val.cpu().detach().item()
             if metric_name.endswith("_step"):
-                step = True
+                step_metrics = True
             metric_name = standardize_metric_name(metric_name, __name__)
             self.experiment.log_metric(name=metric_name, val=metric_val)
-        # Only call next_step for epoch-level metrics
-        if not step:
-            self.experiment.next_step()
+
+        if not step_metrics:
+            self._step_only = False
 
     @rank_zero_only
     def finalize(self, status: str) -> None:
+        # need a final call to make_summary to update step
+        self.experiment.make_summary()
         self.experiment.end()

--- a/tests/test_frameworks/test_lightning.py
+++ b/tests/test_frameworks/test_lightning.py
@@ -171,3 +171,19 @@ def test_lightning_steps(tmp_dir):
     step_loss = history[os.path.join(scalars, "train", "step", "loss.tsv")]
     assert len(epoch_loss) == 2
     assert len(step_loss) == 4
+
+
+def test_lightning_next_step(tmp_dir, mocker):
+    model = LitXOR()
+    dvclive_logger = DVCLiveLogger("test_run")
+    live = dvclive_logger.experiment
+    spy = mocker.spy(live, "next_step")
+    trainer = Trainer(
+        logger=dvclive_logger,
+        max_epochs=2,
+        enable_checkpointing=False,
+        log_every_n_steps=2,
+    )
+    trainer.fit(model)
+
+    assert spy.call_count == 2

--- a/tests/test_frameworks/test_lightning.py
+++ b/tests/test_frameworks/test_lightning.py
@@ -150,10 +150,12 @@ def test_lightning_kwargs(tmp_dir):
     assert not os.path.exists("dir/dvc.yaml")
 
 
-def test_lightning_steps(tmp_dir):
+def test_lightning_steps(tmp_dir, mocker):
     model = LitXOR()
     # Handle kwargs passed to Live.
     dvclive_logger = DVCLiveLogger(dir="logs")
+    live = dvclive_logger.experiment
+    spy = mocker.spy(live, "make_report")
     trainer = Trainer(
         logger=dvclive_logger,
         max_epochs=2,
@@ -172,18 +174,5 @@ def test_lightning_steps(tmp_dir):
     assert len(epoch_loss) == 2
     assert len(step_loss) == 4
 
-
-def test_lightning_next_step(tmp_dir, mocker):
-    model = LitXOR()
-    dvclive_logger = DVCLiveLogger("test_run")
-    live = dvclive_logger.experiment
-    spy = mocker.spy(live, "next_step")
-    trainer = Trainer(
-        logger=dvclive_logger,
-        max_epochs=2,
-        enable_checkpointing=False,
-        log_every_n_steps=2,
-    )
-    trainer.fit(model)
-
+    # call make_report once per epoch
     assert spy.call_count == 2


### PR DESCRIPTION
Fixes #477. Calls `next_step` only for epoch-level metrics, not step-level metrics. It may get called twice each epoch (once for train and once for val), but it's much less frequent than current behavior.
