### PR TITLE
lightning: Determine when to call next_step based on `inspect.stack`.

### DIFF
--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+import inspect
 from typing import Any, Dict, Optional
 
 from lightning_fabric.utilities.logger import (
@@ -11,6 +13,24 @@ from torch import is_tensor
 
 from dvclive import Live
 from dvclive.utils import standardize_metric_name
+
+
+def _should_call_next_step():
+    """
+    Find out if pytorch_lightning is calling `log_metrics` from the functions
+    where we actually want to call `next_step`.
+    For example, prevents calling next_step when external callbacks call
+    `log_metrics` or during the multiple `update_eval_step_metrics`.
+    """
+    return any(
+        frame.function
+        in (
+            "update_train_step_metrics",
+            "update_train_epoch_metrics",
+            "log_eval_end_metrics",
+        )
+        for frame in inspect.stack()
+    )
 
 
 class DVCLiveLogger(Logger):
@@ -79,14 +99,19 @@ class DVCLiveLogger(Logger):
         assert (
             rank_zero_only.rank == 0  # type: ignore
         ), "experiment tried to log from global_rank != 0"
-
         self.experiment.step = step
         for metric_name, metric_val in metrics.items():
             if is_tensor(metric_val):
                 metric_val = metric_val.cpu().detach().item()
             metric_name = standardize_metric_name(metric_name, __name__)
             self.experiment.log_metric(name=metric_name, val=metric_val)
-        self.experiment.next_step()
+        if _should_call_next_step():
+            if step == self.experiment._latest_studio_step:
+                # We are in log_eval_end_metrics but there has been already
+                # a studio request sent with `step`.
+                # We decrease the number to bypass `live.studio._get_unsent_datapoints`
+                self.experiment._latest_studio_step -= 1
+            self.experiment.next_step()
 
     @rank_zero_only
     def finalize(self, status: str) -> None:

--- a/tests/test_frameworks/test_lightning.py
+++ b/tests/test_frameworks/test_lightning.py
@@ -1,6 +1,7 @@
 import os
 
 import torch
+from dvc_studio_client.env import STUDIO_ENDPOINT, STUDIO_REPO_URL, STUDIO_TOKEN
 from pytorch_lightning import LightningModule
 from pytorch_lightning.trainer import Trainer
 from torch import nn
@@ -150,15 +151,18 @@ def test_lightning_kwargs(tmp_dir):
     assert not os.path.exists("dir/dvc.yaml")
 
 
-def test_lightning_steps(tmp_dir):
+def test_lightning_steps(tmp_dir, mocker):
     model = LitXOR()
     # Handle kwargs passed to Live.
     dvclive_logger = DVCLiveLogger(dir="logs")
+    live = dvclive_logger.experiment
+    spy = mocker.spy(live, "next_step")
     trainer = Trainer(
         logger=dvclive_logger,
         max_epochs=2,
         enable_checkpointing=False,
-        log_every_n_steps=2,
+        # Log one time in the middle of the epoch
+        log_every_n_steps=3,
     )
     trainer.fit(model)
 
@@ -170,4 +174,71 @@ def test_lightning_steps(tmp_dir):
     epoch_loss = history[os.path.join(scalars, "train", "epoch", "loss.tsv")]
     step_loss = history[os.path.join(scalars, "train", "step", "loss.tsv")]
     assert len(epoch_loss) == 2
-    assert len(step_loss) == 4
+    assert len(step_loss) == 2
+
+    # call next_step:
+    # - 2x epoch end
+    # - 2x log_every_n_steps
+    assert spy.call_count == 4
+
+
+class ValLitXOR(LitXOR):
+    def val_loader(self):
+        dataset = XORDataset()
+        loader = DataLoader(dataset, batch_size=1)
+        return loader
+
+    def val_dataloader(self):
+        loader = self.val_loader()
+        return loader
+
+    def training_step(self, *args, **kwargs):
+        batch = args[0]
+        x, y = batch
+        logits = self(x)
+        loss = F.nll_loss(logits, y)
+        self.log("train_loss", loss, on_step=True)
+        return loss
+
+    def validation_step(self, *args, **kwargs):
+        batch = args[0]
+        x, y = batch
+        logits = self(x)
+        loss = F.nll_loss(logits, y)
+        self.log("val_loss", loss, on_step=False, on_epoch=True)
+        return loss
+
+
+def test_lightning_val_udpates_to_studio(tmp_dir, mocker, monkeypatch):
+    """Test the `self.experiment._latest_studio_step -= 1` logic."""
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.scm.get_rev.return_value = "f" * 40
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+    mocked_response = mocker.MagicMock()
+    mocked_response.status_code = 200
+    mocked_post = mocker.patch("requests.post", return_value=mocked_response)
+    monkeypatch.setenv(STUDIO_ENDPOINT, "https://0.0.0.0")
+    monkeypatch.setenv(STUDIO_REPO_URL, "STUDIO_REPO_URL")
+    monkeypatch.setenv(STUDIO_TOKEN, "STUDIO_TOKEN")
+
+    model = ValLitXOR()
+    dvclive_logger = DVCLiveLogger()
+    trainer = Trainer(
+        logger=dvclive_logger,
+        max_steps=4,
+        val_check_interval=2,
+        log_every_n_steps=1,
+        enable_checkpointing=False,
+    )
+    trainer.fit(model)
+
+    calls = mocked_post.call_args_list
+    # 0: start
+    # 1: update_train_step_metrics
+    # 2: update_train_step_metrics
+    # 3: log_eval_end_metrics
+    plots = calls[3][1]["json"]["plots"]
+    val_loss = plots["dvclive/dvc.yaml::dvclive/plots/metrics/val/loss.tsv"]
+    # Without `self.experiment._latest_studio_step -= 1`
+    # This would be empty
+    assert len(val_loss["data"]) == 1


### PR DESCRIPTION
Only call next_step for

- `update_train_step_metrics`
- `update_train_epoch_metrics`
- `log_eval_end_metrics`

Prevents calling next_step when external callbacks call `log_metrics` or during the multiple `update_eval_step_metrics`.

Closes #477