### PR TITLE
lightning: prevent conflict with internal `step` property.

### DIFF
--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -91,8 +91,10 @@ def standardize_metric_name(metric_name: str, framework: str) -> str:
         split, freq, rest = None, None, None
         if parts[0] in ["train", "val", "test"]:
             split = parts.pop(0)
-        if parts[-1] in ["step", "epoch"]:
-            freq = parts.pop()
+            # Only set freq if split was also found.
+            # Otherwise we end up conflicting with out internal `step` property.
+            if parts[-1] in ["step", "epoch"]:
+                freq = parts.pop()
         rest = "_".join(parts)
         parts = [part for part in (split, freq, rest) if part]
         metric_name = "/".join(parts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from dvclive.utils import standardize_metric_name
         ("dvclive.lightning", "train_loss", "train/loss"),
         ("dvclive.lightning", "train_loss_epoch", "train/epoch/loss"),
         ("dvclive.lightning", "train_model_error", "train/model_error"),
+        ("dvclive.lightning", "grad_step", "grad_step"),
     ],
 )
 def test_standardize_metric_name(framework, logged, standardized):


### PR DESCRIPTION
If a metric didn't contain `split` but only `freq` suffix, `standardize_metric_name` was causing a conflict in the summary. For example: `grad_step` was being stored as `step/grade`.
