### PR TITLE
log stage template

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -166,11 +166,9 @@ def get_dvc_stage_template(live):
         "outs": [],
     }
     if live._params:
-        params_path = os.path.relpath(live.params_file, live.dir)
-        stage["outs"].append({params_path: {"cache": False}})
+        stage["outs"].append({live.params_file: {"cache": False}})
     if live._metrics:
-        metrics_path = os.path.relpath(live.metrics_file, live.dir)
-        stage["outs"].append({metrics_path: {"cache": False}})
+        stage["outs"].append({live.metrics_file: {"cache": False}})
     if live._metrics or live._images or live._plots:
         plots_path = Path(live.plots_dir).as_posix()
         stage["outs"].append({plots_path: {"cache": False}})

--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -165,12 +165,15 @@ def get_dvc_stage_template(live):
         "deps": ["<my_code_file.py>"],
         "outs": [],
     }
+    rel_path = os.path.relpath(os.getcwd(), live._dvc_repo.root_dir)
     if live._params:
-        stage["outs"].append({live.params_file: {"cache": False}})
+        params_path = (Path(rel_path) / Path(live.params_file)).as_posix()
+        stage["outs"].append({params_path: {"cache": False}})
     if live._metrics:
-        stage["outs"].append({live.metrics_file: {"cache": False}})
+        metrics_path = (Path(rel_path) / Path(live.metrics_file)).as_posix()
+        stage["outs"].append({metrics_path: {"cache": False}})
     if live._metrics or live._images or live._plots:
-        plots_path = Path(live.plots_dir).as_posix()
+        plots_path = (Path(rel_path) / Path(live.plots_dir)).as_posix()
         stage["outs"].append({plots_path: {"cache": False}})
     stage["outs"] += list(live._outs)
     dvcyaml_dict = {"stages": {"dvclive": stage}}

--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -165,17 +165,20 @@ def get_dvc_stage_template(live):
         "deps": ["<my_code_file.py>"],
         "outs": [],
     }
-    rel_path = os.path.relpath(os.getcwd(), live._dvc_repo.root_dir)
+    rel_path = Path(os.path.relpath(os.getcwd(), live._dvc_repo.root_dir))
     if live._params:
-        params_path = (Path(rel_path) / Path(live.params_file)).as_posix()
+        params_path = (rel_path / live.params_file).as_posix()
         stage["outs"].append({params_path: {"cache": False}})
     if live._metrics:
-        metrics_path = (Path(rel_path) / Path(live.metrics_file)).as_posix()
+        metrics_path = (rel_path / live.metrics_file).as_posix()
         stage["outs"].append({metrics_path: {"cache": False}})
     if live._metrics or live._images or live._plots:
-        plots_path = (Path(rel_path) / Path(live.plots_dir)).as_posix()
+        plots_path = (rel_path / live.plots_dir).as_posix()
         stage["outs"].append({plots_path: {"cache": False}})
-    stage["outs"] += list(live._outs)
+    for o in live._outs:
+        artifact_path = Path(os.getcwd()) / o
+        artifact_path = artifact_path.relative_to(live._dvc_repo.root_dir).as_posix()
+        stage["outs"].append(artifact_path)
     dvcyaml_dict = {"stages": {"dvclive": stage}}
 
     output = StringIO()

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -13,6 +13,7 @@ from ruamel.yaml.representer import RepresenterError
 from . import env
 from .dvc import (
     get_dvc_repo,
+    get_dvc_stage_template,
     get_random_exp_name,
     make_checkpoint,
     make_dvcyaml,
@@ -404,6 +405,16 @@ class Live:
                 logger.warning(f"Failed to save experiment:\n{e}")
             finally:
                 mark_dvclive_only_ended()
+
+        if self._dvc_repo and not self._inside_dvc_exp:
+            from dvc.exceptions import DvcException
+
+            try:
+                path = os.path.join(self._dvc_repo.root_dir, "dvc.yaml")
+                yaml = get_dvc_stage_template(self)
+                logger.info(f"To run experiments with DVC, add this to {path}:\n{yaml}")
+            except DvcException as e:
+                logger.warning(f"Failed to print DVC stage template:\n{e}")
 
     def make_checkpoint(self):
         if env2bool(env.DVC_CHECKPOINT):

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -412,7 +412,7 @@ class Live:
             try:
                 path = os.path.join(self._dvc_repo.root_dir, "dvc.yaml")
                 yaml = get_dvc_stage_template(self)
-                logger.info(f"To run experiments with DVC, add this to {path}:\n{yaml}")
+                logger.info(f"To run with DVC, add this to {path}:\n{yaml}")
             except DvcException as e:
                 logger.warning(f"Failed to print DVC stage template:\n{e}")
 

--- a/src/dvclive/serialize.py
+++ b/src/dvclive/serialize.py
@@ -25,7 +25,7 @@ def load_yaml(path, typ="safe"):
             raise YAMLFileCorruptedError(path)
 
 
-def _get_yaml():
+def get_yaml():
     from ruamel.yaml import YAML
 
     yaml = YAML()
@@ -38,7 +38,7 @@ def _get_yaml():
 
 
 def dump_yaml(content, output_file):
-    yaml = _get_yaml()
+    yaml = get_yaml()
     with open(output_file, "w", encoding="utf-8") as fd:
         yaml.dump(content, fd)
 

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -295,11 +295,11 @@ def test_get_dvc_stage_template_artifacts(tmp_dir, mocked_dvc_repo):
     }
 
 
-def test_get_dvc_stage_template_chdir(tmp_dir, mocked_dvc_repo):
+def test_get_dvc_stage_template_chdir(tmp_dir, mocked_dvc_repo, monkeypatch):
     mocked_dvc_repo.root_dir = tmp_dir
     d = tmp_dir / "sub" / "dir"
     d.mkdir(parents=True)
-    os.chdir(d)
+    monkeypatch.chdir(d)
     live = Live("live")
     live.log_param("foo", 1)
     live.log_metric("bar", 1)

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -1,7 +1,5 @@
 # pylint: disable=unused-argument,protected-access
 
-import os
-
 import pytest
 from dvc.repo import Repo
 from PIL import Image
@@ -208,7 +206,6 @@ def test_get_dvc_stage_template_empty(tmp_dir, mocked_dvc_repo):
 
 
 def test_get_dvc_stage_template_params(tmp_dir, mocked_dvc_repo):
-    mocked_dvc_repo.root_dir = tmp_dir
     live = Live()
     live.log_param("foo", 1)
     template = get_dvc_stage_template(live)
@@ -225,7 +222,6 @@ def test_get_dvc_stage_template_params(tmp_dir, mocked_dvc_repo):
 
 
 def test_get_dvc_stage_template_metrics(tmp_dir, mocked_dvc_repo):
-    mocked_dvc_repo.root_dir = tmp_dir
     live = Live()
     live.log_metric("foo", 1)
     template = get_dvc_stage_template(live)
@@ -245,7 +241,6 @@ def test_get_dvc_stage_template_metrics(tmp_dir, mocked_dvc_repo):
 
 
 def test_get_dvc_stage_template_image(tmp_dir, mocked_dvc_repo):
-    mocked_dvc_repo.root_dir = tmp_dir
     live = Live()
     live.log_image("img.png", Image.new("RGB", (10, 10), (250, 250, 250)))
     template = get_dvc_stage_template(live)
@@ -262,7 +257,6 @@ def test_get_dvc_stage_template_image(tmp_dir, mocked_dvc_repo):
 
 
 def test_get_dvc_stage_template_sklearn_plots(tmp_dir, mocked_dvc_repo):
-    mocked_dvc_repo.root_dir = tmp_dir
     live = Live()
     live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [0, 1, 1, 0])
     template = get_dvc_stage_template(live)
@@ -279,7 +273,6 @@ def test_get_dvc_stage_template_sklearn_plots(tmp_dir, mocked_dvc_repo):
 
 
 def test_get_dvc_stage_template_artifacts(tmp_dir, mocked_dvc_repo):
-    mocked_dvc_repo.root_dir = tmp_dir
     live = Live()
     live.log_artifact("artifact.txt")
     template = get_dvc_stage_template(live)
@@ -296,7 +289,6 @@ def test_get_dvc_stage_template_artifacts(tmp_dir, mocked_dvc_repo):
 
 
 def test_get_dvc_stage_template_chdir(tmp_dir, mocked_dvc_repo, monkeypatch):
-    mocked_dvc_repo.root_dir = tmp_dir
     d = tmp_dir / "sub" / "dir"
     d.mkdir(parents=True)
     monkeypatch.chdir(d)

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -3,12 +3,15 @@
 import pytest
 from dvc.repo import Repo
 from PIL import Image
+from ruamel.yaml import YAML
 from scmrepo.git import Git
 
 from dvclive import Live
-from dvclive.dvc import get_dvc_repo, make_dvcyaml
+from dvclive.dvc import get_dvc_repo, get_dvc_stage_template, make_dvcyaml
 from dvclive.env import DVC_EXP_BASELINE_REV, DVC_EXP_NAME
 from dvclive.serialize import load_yaml
+
+YAML_LOADER = YAML(typ="safe")
 
 
 def test_get_dvc_repo(tmp_dir):
@@ -185,3 +188,106 @@ def test_exp_save_dvcexception_is_ignored(tmp_dir, mocker):
 
     with Live(save_dvc_exp=True):
         pass
+
+
+def test_get_dvc_stage_template_empty(tmp_dir, mocked_dvc_repo):
+    live = Live()
+    template = get_dvc_stage_template(live)
+
+    assert YAML_LOADER.load(template) == {
+        "stages": {
+            "dvclive": {
+                "cmd": "<python my_code_file.py my_args>",
+                "deps": ["<my_code_file.py>"],
+                "outs": [],
+            }
+        }
+    }
+
+
+def test_get_dvc_stage_template_params(tmp_dir, mocked_dvc_repo):
+    mocked_dvc_repo.root_dir = tmp_dir
+    live = Live()
+    live.log_param("foo", 1)
+    template = get_dvc_stage_template(live)
+
+    assert YAML_LOADER.load(template) == {
+        "stages": {
+            "dvclive": {
+                "cmd": "<python my_code_file.py my_args>",
+                "deps": ["<my_code_file.py>"],
+                "outs": [{"dvclive/params.yaml": {"cache": False}}],
+            }
+        }
+    }
+
+
+def test_get_dvc_stage_template_metrics(tmp_dir, mocked_dvc_repo):
+    mocked_dvc_repo.root_dir = tmp_dir
+    live = Live()
+    live.log_metric("foo", 1)
+    template = get_dvc_stage_template(live)
+
+    assert YAML_LOADER.load(template) == {
+        "stages": {
+            "dvclive": {
+                "cmd": "<python my_code_file.py my_args>",
+                "deps": ["<my_code_file.py>"],
+                "outs": [
+                    {"dvclive/metrics.json": {"cache": False}},
+                    {"dvclive/plots": {"cache": False}},
+                ],
+            }
+        }
+    }
+
+
+def test_get_dvc_stage_template_image(tmp_dir, mocked_dvc_repo):
+    mocked_dvc_repo.root_dir = tmp_dir
+    live = Live()
+    live.log_image("img.png", Image.new("RGB", (10, 10), (250, 250, 250)))
+    template = get_dvc_stage_template(live)
+
+    assert YAML_LOADER.load(template) == {
+        "stages": {
+            "dvclive": {
+                "cmd": "<python my_code_file.py my_args>",
+                "deps": ["<my_code_file.py>"],
+                "outs": [{"dvclive/plots": {"cache": False}}],
+            }
+        }
+    }
+
+
+def test_get_dvc_stage_template_sklearn_plots(tmp_dir, mocked_dvc_repo):
+    mocked_dvc_repo.root_dir = tmp_dir
+    live = Live()
+    live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [0, 1, 1, 0])
+    template = get_dvc_stage_template(live)
+
+    assert YAML_LOADER.load(template) == {
+        "stages": {
+            "dvclive": {
+                "cmd": "<python my_code_file.py my_args>",
+                "deps": ["<my_code_file.py>"],
+                "outs": [{"dvclive/plots": {"cache": False}}],
+            }
+        }
+    }
+
+
+def test_get_dvc_stage_template_artifacts(tmp_dir, mocked_dvc_repo):
+    mocked_dvc_repo.root_dir = "."
+    live = Live()
+    live.log_artifact("artifact.txt")
+    template = get_dvc_stage_template(live)
+
+    assert YAML_LOADER.load(template) == {
+        "stages": {
+            "dvclive": {
+                "cmd": "<python my_code_file.py my_args>",
+                "deps": ["<my_code_file.py>"],
+                "outs": ["artifact.txt"],
+            }
+        }
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -490,7 +490,6 @@ def test_make_dvcyaml(tmp_dir, dvcyaml):
 def test_get_dvc_stage_template(tmp_dir, mocker, mocked_dvc_repo):
     logger = mocker.patch("dvclive.live.logger")
     dvclive = Live()
-    dvclive._dvc_repo.root_dir = tmp_dir
     dvclive.end()
 
     template = {


### PR DESCRIPTION
Closes #468.

Logs output during `Live.end()` like:

```
INFO:dvclive:To run with DVC, add this to /Users/dave/Code/lstm_seq2seq/dvc.yaml:
stages:
  dvclive:
    cmd: <python my_code_file.py my_args>
    deps:
    - <my_code_file.py>
    outs:
    - dvclive/params.yaml:
        cache: false
    - dvclive/metrics.json:
        cache: false
    - dvclive/plots:
        cache: false
    - model
```
