### PR TITLE
frameworks: Use `log_artifact`.

### DIFF
--- a/src/dvclive/fastai.py
+++ b/src/dvclive/fastai.py
@@ -67,7 +67,8 @@ class DVCLiveCallback(Callback):
         # fast.ai calls after_epoch but we don't want to increase the step.
         if logged_metrics:
             if self.model_file:
-                self.learn.save(self.model_file, with_opt=self.with_opt)
+                file = self.learn.save(self.model_file, with_opt=self.with_opt)
+                self.live.log_artifact(str(file))
             self.live.next_step()
 
     def after_fit(self):
@@ -76,4 +77,7 @@ class DVCLiveCallback(Callback):
         if _inside_fine_tune() and not self.freeze_stage_ended:
             self.freeze_stage_ended = True
         else:
+            if hasattr(self, "save_model"):
+                if self.save_model.last_saved_path:
+                    self.live.log_artifact(str(self.save_model.last_saved_path))
             self.live.end()

--- a/src/dvclive/huggingface.py
+++ b/src/dvclive/huggingface.py
@@ -6,6 +6,7 @@ from transformers import (
     TrainerState,
     TrainingArguments,
 )
+from transformers.trainer import Trainer
 
 from dvclive import Live
 from dvclive.utils import standardize_metric_name
@@ -42,6 +43,7 @@ class DVCLiveCallback(TrainerCallback):
             tokenizer = kwargs.get("tokenizer")
             if tokenizer:
                 tokenizer.save_pretrained(self.model_file)
+            self.live.log_artifact(self.model_file)
 
     def on_train_end(
         self,
@@ -50,4 +52,10 @@ class DVCLiveCallback(TrainerCallback):
         control: TrainerControl,
         **kwargs
     ):
+        if args.load_best_model_at_end:
+            trainer = Trainer(
+                args=args, model=kwargs.get("model"), tokenizer=kwargs.get("tokenizer")
+            )
+            trainer.save_model()
+            self.live.log_artifact(args.output_dir)
         self.live.end()

--- a/src/dvclive/keras.py
+++ b/src/dvclive/keras.py
@@ -51,6 +51,7 @@ class DVCLiveCallback(Callback):
                 self.model.save_weights(self.model_file)
             else:
                 self.model.save(self.model_file)
+            self.live.log_artifact(self.model_file)
         self.live.next_step()
 
     def on_train_end(

--- a/tests/test_frameworks/test_keras.py
+++ b/tests/test_frameworks/test_keras.py
@@ -70,17 +70,20 @@ def test_keras_model_file(tmp_dir, xor_model, mocker, save_weights_only, capture
     save = mocker.spy(model, "save")
     save_weights = mocker.spy(model, "save_weights")
 
+    live_callback = DVCLiveCallback(
+        model_file="model.h5", save_weights_only=save_weights_only
+    )
+    log_artifact = mocker.patch.object(live_callback.live, "log_artifact")
     model.fit(
         x,
         y,
         epochs=1,
         batch_size=1,
-        callbacks=[
-            DVCLiveCallback(model_file="model.h5", save_weights_only=save_weights_only)
-        ],
+        callbacks=[live_callback],
     )
     assert save.call_count != save_weights_only
     assert save_weights.call_count == save_weights_only
+    log_artifact.assert_called_with(live_callback.model_file)
 
 
 @pytest.mark.parametrize("save_weights_only", (True, False))


### PR DESCRIPTION
Tested with setup in https://github.com/iterative/example-get-started-experiments/

```py
from dvclive import Live
from fastai.callback.tracker import SaveModelCallback
train_arch = 'resnet18'

for base_lr in [0.1, 0.01, 0.001]:
    with Live(dir=os.path.join('results', 'train'), save_dvc_exp=True) as live:
        learn = unet_learner(
            data_loader, arch=getattr(models, train_arch), metrics=DiceMulti, 
            path="results")
        fine_tune_args = {
            'epochs': 2,
            'base_lr': base_lr
            }
        live.log_params(fine_tune_args)
        learn.fine_tune(
            **fine_tune_args,
            cbs=[DVCLiveCallback(live=live), SaveModelCallback()])
```

And then retrieving the best model with:

```
!dvc exp show --csv > results.csv
```

```py
import dvc.api
import pandas as pd

results = pd.read_csv("results.csv")
best_exp = results.Experiment[results.dice_multi.argmax()]

with dvc.api.open(
    "results/models/model.pth", rev=best_exp, mode="rb"
) as f:
    learn = learn.load(f)
```