### PR TITLE
studio: Send paths relative to `self._dvc_repo.root_dir`.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -113,7 +113,6 @@ class Live:
                     "Ignoring `_save_dvc_exp` because `dvc exp run` is running"
                 )
                 self._save_dvc_exp = False
-            return
 
         self._dvc_repo = get_dvc_repo()
         if self._dvc_repo is None:
@@ -123,6 +122,9 @@ class Live:
                     "\nYou can create a DVC Repo by calling `dvc init`."
                 )
                 self._save_dvc_exp = False
+            return
+
+        if self._inside_dvc_exp:
             return
 
         self._baseline_rev = self._dvc_repo.scm.get_rev()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+# pylint: disable=redefined-outer-name
 import sys
 
 import pytest
+from dvc_studio_client.env import STUDIO_ENDPOINT, STUDIO_REPO_URL, STUDIO_TOKEN
 
 
 @pytest.fixture
@@ -10,11 +12,12 @@ def tmp_dir(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def mocked_dvc_repo(mocker):
+def mocked_dvc_repo(tmp_dir, mocker):
     _dvc_repo = mocker.MagicMock()
     _dvc_repo.index.stages = []
-    _dvc_repo.scm.get_rev.return_value = "current_rev"
+    _dvc_repo.scm.get_rev.return_value = "f" * 40
     _dvc_repo.scm.get_ref.return_value = None
+    _dvc_repo.root_dir = tmp_dir
     mocker.patch("dvclive.live.get_dvc_repo", return_value=_dvc_repo)
     return _dvc_repo
 
@@ -46,3 +49,14 @@ def mocked_webbrowser_open(mocker):
 @pytest.fixture(autouse=True)
 def mocked_CI(monkeypatch):
     monkeypatch.setenv("CI", "false")
+
+
+@pytest.fixture
+def mocked_studio_post(mocker, monkeypatch):
+    valid_response = mocker.MagicMock()
+    valid_response.status_code = 200
+    mocked_post = mocker.patch("requests.post", return_value=valid_response)
+    monkeypatch.setenv(STUDIO_ENDPOINT, "https://0.0.0.0")
+    monkeypatch.setenv(STUDIO_REPO_URL, "STUDIO_REPO_URL")
+    monkeypatch.setenv(STUDIO_TOKEN, "STUDIO_TOKEN")
+    return mocked_post, valid_response

--- a/tests/test_frameworks/test_lightning.py
+++ b/tests/test_frameworks/test_lightning.py
@@ -1,7 +1,6 @@
 import os
 
 import torch
-from dvc_studio_client.env import STUDIO_ENDPOINT, STUDIO_REPO_URL, STUDIO_TOKEN
 from pytorch_lightning import LightningModule
 from pytorch_lightning.trainer import Trainer
 from torch import nn
@@ -209,17 +208,9 @@ class ValLitXOR(LitXOR):
         return loss
 
 
-def test_lightning_val_udpates_to_studio(tmp_dir, mocker, monkeypatch):
+def test_lightning_val_udpates_to_studio(tmp_dir, mocked_dvc_repo, mocked_studio_post):
     """Test the `self.experiment._latest_studio_step -= 1` logic."""
-    dvc_repo = mocker.MagicMock()
-    dvc_repo.scm.get_rev.return_value = "f" * 40
-    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
-    mocked_response = mocker.MagicMock()
-    mocked_response.status_code = 200
-    mocked_post = mocker.patch("requests.post", return_value=mocked_response)
-    monkeypatch.setenv(STUDIO_ENDPOINT, "https://0.0.0.0")
-    monkeypatch.setenv(STUDIO_REPO_URL, "STUDIO_REPO_URL")
-    monkeypatch.setenv(STUDIO_TOKEN, "STUDIO_TOKEN")
+    mocked_post, _ = mocked_studio_post
 
     model = ValLitXOR()
     dvclive_logger = DVCLiveLogger()


### PR DESCRIPTION
Closes #501

Tested manually against Studio prod with DVCLive only and `dvc exp run`:

https://studio.iterative.ai/user/daavoo/projects/test-dvclive-studio-subdir-tig1qeggo8?panels=plots%2C&commits=6846546%2Cprimary%3B853%2Cpurple%3B850%2Cred%3B6846392%2Cgreen

Also tested setting a custom project dir during Studio import:

https://studio.iterative.ai/user/daavoo/projects/subdir-mtf4f648wn?panels=plots%2C&commits=850%2Cprimary%3B853%2Cpurple%3B6846634%2Cred%3B6846632%2Cgreen

