### PR TITLE
remove dvclive outputs from dvc stage outs

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -163,18 +163,9 @@ def get_dvc_stage_template(live):
     stage = {
         "cmd": "<python my_code_file.py my_args>",
         "deps": ["<my_code_file.py>"],
-        "outs": [],
     }
-    rel_path = Path(os.path.relpath(os.getcwd(), live._dvc_repo.root_dir))
-    if live._params:
-        params_path = (rel_path / live.params_file).as_posix()
-        stage["outs"].append({params_path: {"cache": False}})
-    if live._metrics:
-        metrics_path = (rel_path / live.metrics_file).as_posix()
-        stage["outs"].append({metrics_path: {"cache": False}})
-    if live._metrics or live._images or live._plots:
-        plots_path = (rel_path / live.plots_dir).as_posix()
-        stage["outs"].append({plots_path: {"cache": False}})
+    if live._outs:
+        stage["outs"] = []
     for o in live._outs:
         artifact_path = Path(os.getcwd()) / o
         artifact_path = artifact_path.relative_to(live._dvc_repo.root_dir).as_posix()

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -199,74 +199,6 @@ def test_get_dvc_stage_template_empty(tmp_dir, mocked_dvc_repo):
             "dvclive": {
                 "cmd": "<python my_code_file.py my_args>",
                 "deps": ["<my_code_file.py>"],
-                "outs": [],
-            }
-        }
-    }
-
-
-def test_get_dvc_stage_template_params(tmp_dir, mocked_dvc_repo):
-    live = Live()
-    live.log_param("foo", 1)
-    template = get_dvc_stage_template(live)
-
-    assert YAML_LOADER.load(template) == {
-        "stages": {
-            "dvclive": {
-                "cmd": "<python my_code_file.py my_args>",
-                "deps": ["<my_code_file.py>"],
-                "outs": [{"dvclive/params.yaml": {"cache": False}}],
-            }
-        }
-    }
-
-
-def test_get_dvc_stage_template_metrics(tmp_dir, mocked_dvc_repo):
-    live = Live()
-    live.log_metric("foo", 1)
-    template = get_dvc_stage_template(live)
-
-    assert YAML_LOADER.load(template) == {
-        "stages": {
-            "dvclive": {
-                "cmd": "<python my_code_file.py my_args>",
-                "deps": ["<my_code_file.py>"],
-                "outs": [
-                    {"dvclive/metrics.json": {"cache": False}},
-                    {"dvclive/plots": {"cache": False}},
-                ],
-            }
-        }
-    }
-
-
-def test_get_dvc_stage_template_image(tmp_dir, mocked_dvc_repo):
-    live = Live()
-    live.log_image("img.png", Image.new("RGB", (10, 10), (250, 250, 250)))
-    template = get_dvc_stage_template(live)
-
-    assert YAML_LOADER.load(template) == {
-        "stages": {
-            "dvclive": {
-                "cmd": "<python my_code_file.py my_args>",
-                "deps": ["<my_code_file.py>"],
-                "outs": [{"dvclive/plots": {"cache": False}}],
-            }
-        }
-    }
-
-
-def test_get_dvc_stage_template_sklearn_plots(tmp_dir, mocked_dvc_repo):
-    live = Live()
-    live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [0, 1, 1, 0])
-    template = get_dvc_stage_template(live)
-
-    assert YAML_LOADER.load(template) == {
-        "stages": {
-            "dvclive": {
-                "cmd": "<python my_code_file.py my_args>",
-                "deps": ["<my_code_file.py>"],
-                "outs": [{"dvclive/plots": {"cache": False}}],
             }
         }
     }
@@ -293,10 +225,6 @@ def test_get_dvc_stage_template_chdir(tmp_dir, mocked_dvc_repo, monkeypatch):
     d.mkdir(parents=True)
     monkeypatch.chdir(d)
     live = Live("live")
-    live.log_param("foo", 1)
-    live.log_metric("bar", 1)
-    live.log_image("img.png", Image.new("RGB", (10, 10), (250, 250, 250)))
-    live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [0, 1, 1, 0])
     live.log_artifact("artifact.txt")
     template = get_dvc_stage_template(live)
 
@@ -305,12 +233,7 @@ def test_get_dvc_stage_template_chdir(tmp_dir, mocked_dvc_repo, monkeypatch):
             "dvclive": {
                 "cmd": "<python my_code_file.py my_args>",
                 "deps": ["<my_code_file.py>"],
-                "outs": [
-                    {"sub/dir/live/params.yaml": {"cache": False}},
-                    {"sub/dir/live/metrics.json": {"cache": False}},
-                    {"sub/dir/live/plots": {"cache": False}},
-                    "sub/dir/artifact.txt",
-                ],
+                "outs": ["sub/dir/artifact.txt"],
             }
         }
     }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -497,7 +497,6 @@ def test_get_dvc_stage_template(tmp_dir, mocker, mocked_dvc_repo):
             "dvclive": {
                 "cmd": "<python my_code_file.py my_args>",
                 "deps": ["<my_code_file.py>"],
-                "outs": [],
             }
         }
     }


### PR DESCRIPTION
Drop dvclive outs from printed stage template.

Related:
* https://github.com/iterative/example-repos-dev/pull/191#discussion_r1147486180
* https://github.com/iterative/dvclive/issues/456
* https://github.com/iterative/dvc.org/pull/4389#discussion_r1140805922
