### PR TITLE
live: Explicitly require `exp` for sending Studio updates.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -70,7 +70,7 @@ class Live:
             self._init_cleanup()
 
         self._baseline_rev: Optional[str] = None
-        self._exp_name: str = "dvclive-exp"
+        self._exp_name: Optional[str] = None
         self._experiment_rev: Optional[str] = None
         self._inside_dvc_exp: bool = False
         self._dvc_repo = None
@@ -146,8 +146,17 @@ class Live:
             self._studio_events_to_skip.add("done")
         elif self._dvc_repo is None:
             logger.warning(
-                "Can't send updates to Studio without a DVC Repo."
+                "Can't connect to Studio without a DVC Repo."
                 "\nYou can create a DVC Repo by calling `dvc init`."
+            )
+            self._studio_events_to_skip.add("start")
+            self._studio_events_to_skip.add("data")
+            self._studio_events_to_skip.add("done")
+        elif not self._save_dvc_exp:
+            logger.warning(
+                "Can't connect to Studio without creating a DVC experiment."
+                "\nIf you have a DVC Pipeline, run it with `dvc exp run`."
+                "\nIf you are using DVCLive alone, use `save_dvc_exp=True`."
             )
             self._studio_events_to_skip.add("start")
             self._studio_events_to_skip.add("data")

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -94,7 +94,7 @@ def test_exp_save_on_end(tmp_dir, save, mocked_dvc_repo):
     live.end()
     if save:
         assert live._baseline_rev is not None
-        assert live._exp_name != "dvclive-exp"
+        assert live._exp_name is not None
         mocked_dvc_repo.experiments.save.assert_called_with(
             name=live._exp_name,
             include_untracked=[live.dir],
@@ -102,7 +102,7 @@ def test_exp_save_on_end(tmp_dir, save, mocked_dvc_repo):
         )
     else:
         assert live._baseline_rev is not None
-        assert live._exp_name == "dvclive-exp"
+        assert live._exp_name is None
         mocked_dvc_repo.experiments.save.assert_not_called()
 
 
@@ -131,7 +131,7 @@ def test_exp_save_run_on_dvc_repro(tmp_dir, mocker):
         live = Live(save_dvc_exp=True)
         assert live._save_dvc_exp
         assert live._baseline_rev is not None
-        assert live._exp_name != "dvclive-exp"
+        assert live._exp_name is not None
         live.end()
 
     dvc_repo.experiments.save.assert_called_with(

--- a/tests/test_frameworks/test_lightning.py
+++ b/tests/test_frameworks/test_lightning.py
@@ -213,7 +213,7 @@ def test_lightning_val_udpates_to_studio(tmp_dir, mocked_dvc_repo, mocked_studio
     mocked_post, _ = mocked_studio_post
 
     model = ValLitXOR()
-    dvclive_logger = DVCLiveLogger()
+    dvclive_logger = DVCLiveLogger(save_dvc_exp=True)
     trainer = Trainer(
         logger=dvclive_logger,
         max_steps=4,


### PR DESCRIPTION
Requires using either `dvc exp run` or `save_dvc_exp=True`.

Closes https://github.com/iterative/dvclive/issues/474