### PR TITLE
live: Track `self._dir` when `self._inside_dvc_exp`.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -377,9 +377,11 @@ class Live:
             # Prevent `live.end` calls inside context manager
             return
         self.make_summary(update_step=False)
-
         if self._dvcyaml:
             self.make_dvcyaml()
+
+        if self._inside_dvc_exp and self._dvc_repo:
+            self._dvc_repo.scm.add(self._dir)
 
         if "done" not in self._studio_events_to_skip:
             response = False

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -241,3 +241,12 @@ def test_get_dvc_stage_template_chdir(tmp_dir, mocked_dvc_repo, monkeypatch):
             }
         }
     }
+
+
+def test_live_dir_is_included_in_dvc_exp_run(tmp_dir, mocked_dvc_repo, monkeypatch):
+    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "foo")
+    monkeypatch.setenv(DVC_EXP_NAME, "bar")
+    live = Live()
+    live.log_metric("foo", 1)
+    live.end()
+    live._dvc_repo.scm.add.assert_called_with(live.dir)


### PR DESCRIPTION
Closes #510

```bash
git init repo
cd repo
dvc init
git add .
git commit -m "setup"

echo "from random import random

from dvclive import Live

NUM_EPOCHS = 2

with Live(save_dvc_exp=True) as live:
    live.log_param('epochs', NUM_EPOCHS)

    for epoch in range(NUM_EPOCHS):

        live.log_metric('metric_name1', random())
        live.next_step()" > train.py

echo "stages:
  train:
    cmd: python train.py" > dvc.yaml

dvc exp run
dvc exp show
```

```
 ──────────────────────────────────────────────────────────────────── 
  Experiment                 Created    metric_name1   step   epochs  
 ──────────────────────────────────────────────────────────────────── 
  workspace                  -               0.92207      1   2       
  master                     04:37 PM              -      -   -       
  └── a65edf1 [unfit-code]   04:37 PM        0.92207      1   2       
 ──────────────────────────────────────────────────────────────────── 
```
