### PR TITLE
optuna: Use `summary` instead of `log_metric`.

### DIFF
--- a/src/dvclive/optuna.py
+++ b/src/dvclive/optuna.py
@@ -43,4 +43,4 @@ class DVCLiveCallback:
 
         metrics = {name: val for name, val in zip(names, values)}
         for k, v in metrics.items():
-            live.log_metric(k, v)
+            live.summary[k] = v

--- a/tests/test_frameworks/test_optuna.py
+++ b/tests/test_frameworks/test_optuna.py
@@ -25,3 +25,5 @@ def test_optuna_(tmp_dir, mocked_dvc_repo):
     assert metric_name in metrics
     params = load_yaml("dvclive-optuna/params.yaml")
     assert "x" in params
+
+    assert not (tmp_dir / "dvclive-optuna" / "plots").exists()


### PR DESCRIPTION
Prevent creation of single-row `.tsv` files.

Each trial creates a single DVC experiment and logs metrics a single time.