### PR TITLE
Support path to an image in `log_image`

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -269,6 +269,11 @@ class Live:
         if not Image.could_log(val):
             raise InvalidDataTypeError(name, type(val))
 
+        if isinstance(val, str) or isinstance(val, Path):
+            from PIL import Image as ImagePIL
+
+            val = ImagePIL.open(val)
+
         if name in self._images:
             data = self._images[name]
         else:

--- a/src/dvclive/plots/image.py
+++ b/src/dvclive/plots/image.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from .base import Data
 
@@ -18,6 +18,8 @@ class Image(Data):
         if val.__class__.__module__ == "PIL.Image":
             return True
         if val.__class__.__module__ == "numpy":
+            return True
+        if isinstance(val, PurePath) or isinstance(val, str):
             return True
         return False
 

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -24,11 +24,38 @@ def test_invalid_extension(tmp_dir):
 
 @pytest.mark.parametrize("shape", [(10, 10), (10, 10, 3), (10, 10, 4)])
 def test_numpy(tmp_dir, shape):
+    from PIL import Image as ImagePIL
+
     live = Live()
     img = np.ones(shape, np.uint8) * 255
     live.log_image("image.png", img)
 
-    assert (tmp_dir / live.plots_dir / LiveImage.subfolder / "image.png").exists()
+    img_path = tmp_dir / live.plots_dir / LiveImage.subfolder / "image.png"
+    assert img_path.exists()
+
+    val = np.asarray(ImagePIL.open(img_path))
+    assert np.array_equal(val, img)
+
+
+def test_path(tmp_dir):
+    import numpy as np
+    from PIL import Image as ImagePIL
+
+    live = Live()
+    image_data = np.random.randint(0, 255, (100, 100, 3)).astype(np.uint8)
+    pil_image = ImagePIL.fromarray(image_data)
+    image_path = tmp_dir / "temp.png"
+    pil_image.save(image_path)
+
+    live = Live()
+    live.log_image("foo.png", image_path)
+    live.end()
+
+    plot_file = tmp_dir / live.plots_dir / "images" / "foo.png"
+    assert plot_file.exists()
+
+    val = np.asarray(ImagePIL.open(plot_file))
+    assert np.array_equal(val, image_data)
 
 
 def test_override_on_step(tmp_dir):


### PR DESCRIPTION
Log image from an existing file. Helps to convert a repo like YOLO where images are produced already by some core code and we need to capture and transfer them into the DVCLive output dir.

It also adds some test for `log_image`.

Related: https://github.com/shcheklein/ultralytics
Related: https://github.com/ultralytics/ultralytics/issues/1909

Docs https://github.com/iterative/dvc.org/pull/4463

-------

* [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.
* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
