### PR TITLE
fix(readme): broken links for docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,9 @@ DVCLive is a Python library for logging machine learning metrics and other metad
 `Documentation <https://dvc.org/doc/dvclive>`_
 ----------------------------------------------
 
-- `Get Started <https://dvc.org/doc/dvclive/get-started>`_
+- `Get Started <https://dvc.org/doc/start/experiments>`_
 - `How it Works <https://dvc.org/doc/dvclive/how-it-works>`_
-- `API Reference <https://dvc.org/doc/dvclive/api-reference>`_
+- `API Reference <https://dvc.org/doc/dvclive/live>`_
 
 Installation
 ------------


### PR DESCRIPTION
There were a few links to update. One of them was 404ing. It means we are missing a redirect to the API reference in the docs? (cc @daavoo )

-------

* [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
