### PR TITLE
studio: Save experiment before posting `done` event.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -388,6 +388,8 @@ class Live:
 
         self._ensure_paths_are_tracked_in_dvc_exp()
 
+        self.save_dvc_exp()
+
         if "done" not in self._studio_events_to_skip:
             response = False
             if post_live_metrics is not None:
@@ -407,8 +409,6 @@ class Live:
             self._studio_events_to_skip.add("data")
         else:
             self.make_report()
-
-        self.save_dvc_exp()
 
         if self._dvc_repo and not self._inside_dvc_exp:
             from dvc.exceptions import DvcException

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def mocked_dvc_repo(tmp_dir, mocker):
     _dvc_repo.index.stages = []
     _dvc_repo.scm.get_rev.return_value = "f" * 40
     _dvc_repo.scm.get_ref.return_value = None
+    _dvc_repo.experiments.save.return_value = "e" * 40
     _dvc_repo.root_dir = tmp_dir
     mocker.patch("dvclive.live.get_dvc_repo", return_value=_dvc_repo)
     return _dvc_repo

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -87,6 +87,7 @@ def test_post_to_studio(tmp_dir, mocked_dvc_repo, mocked_studio_post):
             "type": "done",
             "repo_url": "STUDIO_REPO_URL",
             "baseline_sha": "f" * 40,
+            "experiment_rev": live._experiment_rev,
             "name": live._exp_name,
             "client": "dvclive",
         },


### PR DESCRIPTION
To ensure `experiment_rev` is sent.

Found that it was the underlying issue of https://github.com/iterative/studio/issues/5673#issuecomment-1508480082. I thought Studio relied on `baseline_sha`, `exp_name` pair to match live experiments with experiment ref.

Regardless, this was a plain bug that had to be fixed and went under the radar.
