### PR TITLE
only log from dvclive

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -1,5 +1,4 @@
 # ruff: noqa: SLF001
-import logging
 import os
 import random
 from pathlib import Path
@@ -7,10 +6,6 @@ from pathlib import Path
 from dvclive import env
 from dvclive.plots import Image, Metric
 from dvclive.serialize import dump_yaml
-
-logging.basicConfig()
-logger = logging.getLogger("dvclive")
-logger.setLevel(os.getenv(env.DVCLIVE_LOGLEVEL, "INFO").upper())
 
 _CHECKPOINT_SLEEP = 0.1
 

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -32,8 +32,9 @@ from .serialize import dump_json, dump_yaml, load_yaml
 from .studio import get_studio_updates
 from .utils import env2bool, inside_notebook, matplotlib_installed, open_file_in_browser
 
-logging.basicConfig()
 logger = logging.getLogger("dvclive")
+logger.addHandler(logging.StreamHandler())
+logger.addHandler(logging.FileHandler("dvclive.log"))
 logger.setLevel(os.getenv(env.DVCLIVE_LOGLEVEL, "INFO").upper())
 
 ParamLike = Union[int, float, str, bool, List["ParamLike"], Dict[str, "ParamLike"]]

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -33,8 +33,10 @@ from .studio import get_studio_updates
 from .utils import env2bool, inside_notebook, matplotlib_installed, open_file_in_browser
 
 logger = logging.getLogger("dvclive")
-logger.addHandler(logging.StreamHandler())
-logger.addHandler(logging.FileHandler("dvclive.log"))
+handler = logging.StreamHandler()
+formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 logger.setLevel(os.getenv(env.DVCLIVE_LOGLEVEL, "INFO").upper())
 
 ParamLike = Union[int, float, str, bool, List["ParamLike"], Dict[str, "ParamLike"]]

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -1,12 +1,9 @@
 # ruff: noqa: SLF001
-import logging
 import os
 from pathlib import Path
 
 from dvclive.serialize import load_yaml
 from dvclive.utils import parse_metrics
-
-logger = logging.getLogger(__name__)
 
 
 def _get_unsent_datapoints(plot, latest_step):


### PR DESCRIPTION
@daavoo Not sure whether this is what you meant in https://github.com/iterative/dvclive/pull/539#issuecomment-1520147819. This keeps the UI messages but hides the logging messages from DVC. I see there were loggers set up in other modules, but they don't look like they are used now, so I dropped them.

Before this PR:

```
Initialized DVC repository.

INFO:dvc.repo.init:Initialized DVC repository.

You can now commit the changes to git.

INFO:dvc.repo.init:You can now commit the changes to git.

WARNING:dvclive:Can't save experiment to an empty Git Repo.
Add a commit (`git commit`) to save experiments.
```

After this PR:

```
Initialized DVC repository.

You can now commit the changes to git.

WARNING:dvclive:Can't save experiment to an empty Git Repo.
Add a commit (`git commit`) to save experiments.
```