### PR TITLE
logging artifacts in optuna callback

### DIFF
--- a/src/dvclive/optuna.py
+++ b/src/dvclive/optuna.py
@@ -13,6 +13,16 @@ class DVCLiveCallback:
         with Live(save_dvc_exp=True, **self.live_kwargs) as live:
             self._log_metrics(trial.values, live)
             live.log_params(trial.params)
+            self._log_artifact(trial, live)
+
+    def _log_artifact(self, trial, live):
+        artifact_path = trial.user_attrs.get("artifact_path")
+        artifact_name = trial.user_attrs.get("artifact_name")
+
+        if artifact_path:
+            live.log_artifact(artifact_path, name=artifact_name)
+        elif artifact_name:
+            pass  # TODO Raise a warning? Perhaps the user forgot to specify the path...
 
     def _log_metrics(self, values, live):
         if values is None:


### PR DESCRIPTION
Adding a method to log artifacts. It requires the user to [add user defined attributes](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.set_user_attr) called `artifact_path` and (optionally) `artifact_name` to the optuna trial.

I am not very happy with that being necessary but I don't see any other way to integrate this functionality into the callback.

The functionality can be tested by following the README.md using  [this simple example](https://github.com/tibor-mach/dvclive-optuna)