### PR TITLE
live: Catch errors in `_ensure_paths_are_tracked_in_dvc_exp`.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -512,13 +512,16 @@ class Live:
             outs_spec = PathSpec.from_lines(
                 "gitwildmatch", [str(o) for o in self._dvc_repo.index.outs]
             )
-            paths_to_track = [
-                f
-                for f in self._dvc_repo.scm.untracked_files()
-                if (dir_spec.match_file(f) and not outs_spec.match_file(f))
-            ]
-            if paths_to_track:
-                self._dvc_repo.scm.add(paths_to_track)
+            try:
+                paths_to_track = [
+                    f
+                    for f in self._dvc_repo.scm.untracked_files()
+                    if (dir_spec.match_file(f) and not outs_spec.match_file(f))
+                ]
+                if paths_to_track:
+                    self._dvc_repo.scm.add(paths_to_track)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Failed to git add paths:\n{e}")
 
     def save_dvc_exp(self):
         if self._save_dvc_exp:

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -258,3 +258,13 @@ def test_dvc_outs_are_not_added(tmp_dir, mocked_dvc_repo, monkeypatch):
         live.next_step()
 
     live._dvc_repo.scm.add.assert_called_with(["dvclive/metrics.json"])
+
+
+def test_errors_on_git_add_are_catched(tmp_dir, mocked_dvc_repo, monkeypatch):
+    monkeypatch.setenv(DVC_EXP_BASELINE_REV, "foo")
+    monkeypatch.setenv(DVC_EXP_NAME, "bar")
+    mocked_dvc_repo.scm.untracked_files.return_value = ["dvclive/metrics.json"]
+    mocked_dvc_repo.scm.add.side_effect = Exception("foo")
+
+    with Live(report=None) as live:
+        live.summary["foo"] = 1


### PR DESCRIPTION
For #547
