### PR TITLE
feat(log_artifact): add an option to copy (capture) into dvclive dir

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -30,7 +30,14 @@ from .plots import PLOT_TYPES, SKLEARN_PLOTS, CustomPlot, Image, Metric, NumpyEn
 from .report import BLANK_NOTEBOOK_REPORT, make_report
 from .serialize import dump_json, dump_yaml, load_yaml
 from .studio import get_studio_updates
-from .utils import env2bool, inside_notebook, matplotlib_installed, open_file_in_browser
+from .utils import (
+    StrPath,
+    clean_and_copy_into,
+    env2bool,
+    inside_notebook,
+    matplotlib_installed,
+    open_file_in_browser,
+)
 
 logger = logging.getLogger("dvclive")
 handler = logging.StreamHandler()
@@ -40,7 +47,6 @@ logger.addHandler(handler)
 logger.setLevel(os.getenv(env.DVCLIVE_LOGLEVEL, "INFO").upper())
 
 ParamLike = Union[int, float, str, bool, List["ParamLike"], Dict[str, "ParamLike"]]
-StrPath = Union[str, Path]
 
 
 class Live:
@@ -231,6 +237,10 @@ class Live:
         return os.path.join(self.dir, "plots")
 
     @property
+    def artifacts_dir(self) -> str:
+        return os.path.join(self.dir, "artifacts")
+
+    @property
     def report_file(self) -> Optional[str]:
         if self._report_mode in ("html", "md", "notebook"):
             suffix = "html" if self._report_mode == "notebook" else self._report_mode
@@ -380,6 +390,7 @@ class Live:
         desc: Optional[str] = None,  # noqa: ARG002
         labels: Optional[List[str]] = None,  # noqa: ARG002
         meta: Optional[Dict[str, Any]] = None,  # noqa: ARG002
+        copy: bool = False,
     ):
         """Tracks a local file or directory with DVC"""
         if not isinstance(path, (str, Path)):
@@ -387,6 +398,9 @@ class Live:
 
         if self._dvc_repo is not None:
             from dvc.repo.artifacts import name_is_compatible
+
+            if copy:
+                path = clean_and_copy_into(path, self.artifacts_dir)
 
             try:
                 stage = self._dvc_repo.add(path)

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -2,9 +2,13 @@ import csv
 import json
 import os
 import re
+import shutil
 import webbrowser
 from pathlib import Path
 from platform import uname
+from typing import Union
+
+StrPath = Union[str, Path]
 
 
 def run_once(f):
@@ -125,3 +129,22 @@ def inside_notebook() -> bool:
 
         return IPython.__version__ >= "6.0.0"
     return False
+
+
+def clean_and_copy_into(src: StrPath, dst: StrPath) -> str:
+    Path(dst).mkdir(exist_ok=True)
+
+    basename = os.path.basename(os.path.normpath(src))
+    dst_path = Path(os.path.join(dst, basename))
+
+    if dst_path.is_file() or dst_path.is_symlink():
+        dst_path.unlink()
+    elif dst_path.is_dir():
+        shutil.rmtree(dst_path)
+
+    if os.path.isdir(src):
+        shutil.copytree(src, dst_path)
+    else:
+        shutil.copy2(src, dst_path)
+
+    return str(dst_path)


### PR DESCRIPTION
Closes #550

```python
    with Live() as live:
        live.log_artifact("model.pth", copy=True)
```

It copies a file into `dvclive/artifacts/model.pth` and tracks it with DVC in a regular way.

---------

- [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md) guide.

TODO (when accepted):

- [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I  have created a separate PR (or issue, at least) in
  [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

