### PR TITLE
support metrics from multiple eval sets in lgbm

### DIFF
--- a/src/dvclive/lgbm.py
+++ b/src/dvclive/lgbm.py
@@ -11,9 +11,8 @@ class DVCLiveCallback:
 
     def __call__(self, env):
         for eval_result in env.evaluation_result_list:
-            metric = eval_result[1]
-            value = eval_result[2]
-            self.live.log_metric(metric, value)
+            data_name, eval_name, result = eval_result[:3]
+            self.live.log_metric(f"{data_name}-{eval_name}", result)
 
         if self.model_file:
             env.model.save_model(self.model_file)

--- a/src/dvclive/lgbm.py
+++ b/src/dvclive/lgbm.py
@@ -10,9 +10,12 @@ class DVCLiveCallback:
         self.live = live if live is not None else Live(**kwargs)
 
     def __call__(self, env):
+        multi_eval = len(env.evaluation_result_list) > 1
         for eval_result in env.evaluation_result_list:
             data_name, eval_name, result = eval_result[:3]
-            self.live.log_metric(f"{data_name}-{eval_name}", result)
+            self.live.log_metric(
+                f"{data_name}/{eval_name}" if multi_eval else eval_name, result
+            )
 
         if self.model_file:
             env.model.save_model(self.model_file)

--- a/tests/test_frameworks/test_lgbm.py
+++ b/tests/test_frameworks/test_lgbm.py
@@ -46,7 +46,34 @@ def test_lgbm_integration(tmp_dir, model_params, iris_data):
     assert os.path.exists("dvclive")
 
     logs, _ = parse_metrics(callback.live)
+    assert "dvclive/plots/metrics/multi_logloss.tsv" in logs
     assert len(logs) == 1
+    assert len(list(logs.values())[0]) == 5
+
+
+@pytest.mark.skipif(platform == "darwin", reason="LIBOMP Segmentation fault on MacOS")
+def test_lgbm_integration_multi_eval(tmp_dir, model_params, iris_data):
+    model = lgbm.LGBMClassifier()
+    model.set_params(**model_params)
+
+    callback = DVCLiveCallback()
+    model.fit(
+        iris_data[0][0],
+        iris_data[0][1],
+        eval_set=[
+            (iris_data[0][0], iris_data[0][1]),
+            (iris_data[1][0], iris_data[1][1]),
+        ],
+        eval_metric=["multi_logloss"],
+        callbacks=[callback],
+    )
+
+    assert os.path.exists("dvclive")
+
+    logs, _ = parse_metrics(callback.live)
+    assert "dvclive/plots/metrics/training/multi_logloss.tsv" in logs
+    assert "dvclive/plots/metrics/valid_1/multi_logloss.tsv" in logs
+    assert len(logs) == 2
     assert len(list(logs.values())[0]) == 5
 
 


### PR DESCRIPTION
Using multiple "eval_sets" would result in many points being logged on the same graph of dvc. I extended the DVCLiveCallback class locally and changed the __call__ definition to support logging for different eval_sets in different graphs.

- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md)
  guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
