### PR TITLE
fix(log_artifact): don't follow symlink on dumping dvc.yaml

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -108,7 +108,7 @@ def make_dvcyaml(live):
     if live._artifacts:
         dvcyaml["artifacts"] = live._artifacts
         for artifact in dvcyaml["artifacts"].values():
-            abs_path = os.path.realpath(artifact["path"])
+            abs_path = os.path.abspath(artifact["path"])
             abs_dir = os.path.realpath(live.dir)
             relative_path = os.path.relpath(abs_path, abs_dir)
             artifact["path"] = Path(relative_path).as_posix()

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -58,6 +58,18 @@ def test_log_artifact_type_model(tmp_dir, mocked_dvc_repo):
     }
 
 
+def test_log_artifact_dvc_symlink(tmp_dir, dvc_repo):
+    (tmp_dir / "model.pth").touch()
+
+    with Live() as live:
+        live._dvc_repo.cache.local.cache_types = ["symlink"]
+        live.log_artifact("model.pth", type="model")
+
+    assert load_yaml(live.dvc_file) == {
+        "artifacts": {"model": {"path": "../model.pth", "type": "model"}}
+    }
+
+
 def test_log_artifact_type_model_provided_name(tmp_dir, mocked_dvc_repo):
     (tmp_dir / "model.pth").touch()
 


### PR DESCRIPTION
Found this while iterating on the #559 

It was logging path name as:

```python
{'artifacts': {'model': {'path': '../.dvc/cache/d4/1d8cd98f00b204e9800998ecf8427e', 'type': 'model'}}}
```

---------

- [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md)
  guide.
- [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
