### PR TITLE
live: Add `exp_message` arg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir=
     =src
 packages = find:
 install_requires=
-    dvc>=2.58.0
+    dvc>=2.58.0,<3
     dvc-render>=0.5.0,<1.0
     dvc-studio-client>=0.9.2,<1
     funcy

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -56,6 +56,7 @@ class Live:
         report: Optional[str] = "auto",
         save_dvc_exp: bool = False,
         dvcyaml: bool = True,
+        exp_message: Optional[str] = None,
     ):
         self.summary: Dict[str, Any] = {}
 
@@ -84,6 +85,7 @@ class Live:
 
         self._baseline_rev: Optional[str] = None
         self._exp_name: Optional[str] = None
+        self._exp_message: Optional[str] = exp_message
         self._experiment_rev: Optional[str] = None
         self._inside_dvc_exp: bool = False
         self._dvc_repo = None
@@ -191,6 +193,7 @@ class Live:
                 self._exp_name,
                 "dvclive",
                 dvc_studio_config=self._dvc_studio_config,
+                message=self._exp_message,
             )
             if not response:
                 logger.debug(
@@ -553,6 +556,7 @@ class Live:
                     name=self._exp_name,
                     include_untracked=self._include_untracked,
                     force=True,
+                    message=self._exp_message,
                 )
             except DvcException as e:
                 logger.warning(f"Failed to save experiment:\n{e}")

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -133,6 +133,7 @@ def test_exp_save_on_end(tmp_dir, save, mocked_dvc_repo):
             name=live._exp_name,
             include_untracked=[live.dir],
             force=True,
+            message=None,
         )
     else:
         assert live._baseline_rev is not None
@@ -171,7 +172,7 @@ def test_exp_save_run_on_dvc_repro(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_called_with(
-        name=live._exp_name, include_untracked=[live.dir], force=True
+        name=live._exp_name, include_untracked=[live.dir], force=True, message=None
     )
 
 
@@ -210,7 +211,7 @@ def test_exp_save_with_dvc_files(tmp_dir, mocker):
         live.end()
 
     dvc_repo.experiments.save.assert_called_with(
-        name=live._exp_name, include_untracked=[live.dir], force=True
+        name=live._exp_name, include_untracked=[live.dir], force=True, message=None
     )
 
 
@@ -286,3 +287,14 @@ def test_make_dvcyaml_idempotent(tmp_dir, mocked_dvc_repo):
             "model": {"path": "../model.pth", "type": "model"},
         }
     }
+
+
+def test_exp_save_message(tmp_dir, mocked_dvc_repo):
+    live = Live(save_dvc_exp=True, exp_message="Custom message")
+    live.end()
+    mocked_dvc_repo.experiments.save.assert_called_with(
+        name=live._exp_name,
+        include_untracked=[live.dir],
+        force=True,
+        message="Custom message",
+    )

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -47,6 +47,7 @@ def test_log_artifact_with_save_dvc_exp(tmp_dir, mocker, mocked_dvc_repo):
         name=live._exp_name,
         include_untracked=[live.dir, "data", ".gitignore"],
         force=True,
+        message=None,
     )
 
 

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -462,3 +462,26 @@ def test_post_to_studio_images(tmp_dir, mocked_dvc_repo, mocked_studio_post):
         },
         timeout=5,
     )
+
+
+def test_post_to_studio_message(tmp_dir, mocked_dvc_repo, mocked_studio_post):
+    live = Live(save_dvc_exp=True, exp_message="Custom message")
+
+    mocked_post, _ = mocked_studio_post
+
+    mocked_post.assert_called_with(
+        "https://0.0.0.0/api/live",
+        json={
+            "type": "start",
+            "repo_url": "STUDIO_REPO_URL",
+            "baseline_sha": "f" * 40,
+            "name": live._exp_name,
+            "client": "dvclive",
+            "message": "Custom message",
+        },
+        headers={
+            "Authorization": "token STUDIO_TOKEN",
+            "Content-type": "application/json",
+        },
+        timeout=5,
+    )


### PR DESCRIPTION
Use it in the `start` event of post_live_metrics and `experiments.save`.

Closes https://github.com/iterative/dvclive/issues/557


https://github.com/iterative/dvclive/assets/12677733/d7d8ef37-3843-4d7e-aa4c-140443bc7637

