### PR TITLE
fix(make_dvcyaml): make it idempotent for artifacts

### DIFF
--- a/src/dvclive/dvc.py
+++ b/src/dvclive/dvc.py
@@ -1,4 +1,5 @@
 # ruff: noqa: SLF001
+import copy
 import os
 import random
 from pathlib import Path
@@ -106,7 +107,7 @@ def make_dvcyaml(live):
         dvcyaml["plots"] = plots
 
     if live._artifacts:
-        dvcyaml["artifacts"] = live._artifacts
+        dvcyaml["artifacts"] = copy.deepcopy(live._artifacts)
         for artifact in dvcyaml["artifacts"].values():
             abs_path = os.path.abspath(artifact["path"])
             abs_dir = os.path.realpath(live.dir)

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -271,3 +271,18 @@ def test_errors_on_git_add_are_catched(tmp_dir, mocked_dvc_repo, monkeypatch):
 
     with Live(report=None) as live:
         live.summary["foo"] = 1
+
+
+def test_make_dvcyaml_idempotent(tmp_dir, mocked_dvc_repo):
+    (tmp_dir / "model.pth").touch()
+
+    with Live() as live:
+        live.log_artifact("model.pth", type="model")
+
+    live.make_dvcyaml()
+
+    assert load_yaml(live.dvc_file) == {
+        "artifacts": {
+            "model": {"path": "../model.pth", "type": "model"},
+        }
+    }

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -149,7 +149,7 @@ def test_log_artifact_type_model_provided_name(tmp_dir, mocked_dvc_repo):
     }
 
 
-def test_log_artifact_type_model_on_step(tmp_dir, mocked_dvc_repo):
+def test_log_artifact_type_model_on_step_and_final(tmp_dir, mocked_dvc_repo):
     (tmp_dir / "model.pth").touch()
 
     with Live() as live:
@@ -160,6 +160,22 @@ def test_log_artifact_type_model_on_step(tmp_dir, mocked_dvc_repo):
     assert load_yaml(live.dvc_file) == {
         "artifacts": {
             "model": {"path": "../model.pth", "type": "model", "labels": ["final"]},
+        },
+        "metrics": ["metrics.json"],
+    }
+
+
+def test_log_artifact_type_model_on_step(tmp_dir, mocked_dvc_repo):
+    (tmp_dir / "model.pth").touch()
+
+    with Live() as live:
+        for _ in range(3):
+            live.log_artifact("model.pth", type="model")
+            live.next_step()
+
+    assert load_yaml(live.dvc_file) == {
+        "artifacts": {
+            "model": {"path": "../model.pth", "type": "model"},
         },
         "metrics": ["metrics.json"],
     }


### PR DESCRIPTION
Fixes code like this:

```python
    with Live() as live:
        for _ in range(3):
            live.log_artifact("model.pth", type="model")
            live.next_step()
```

Here `make_dvcyaml` is called twice in a row at the end. Previous it was causing artifacts paths to be modified each time (adding a relative level of `..`).


-----------

- [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md)
  guide.

- [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
