### PR TITLE
check for no_scm repo

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -120,6 +120,8 @@ class Live:
                 os.remove(f)
 
     def _init_dvc(self):
+        from dvc.scm import NoSCM
+
         if os.getenv(env.DVC_EXP_BASELINE_REV, None):
             # `dvc exp` execution
             self._baseline_rev = os.getenv(env.DVC_EXP_BASELINE_REV, "")
@@ -132,7 +134,7 @@ class Live:
                 self._save_dvc_exp = False
 
         self._dvc_repo = get_dvc_repo()
-        if self._dvc_repo is None:
+        if (self._dvc_repo is None) or isinstance(self._dvc_repo.scm, NoSCM):
             if self._save_dvc_exp:
                 logger.warning(
                     "Can't save experiment without a Git Repo."

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from dvc.repo import Repo
+from dvc.scm import NoSCM
 from PIL import Image
 from ruamel.yaml import YAML
 from scmrepo.git import Git
@@ -298,3 +299,15 @@ def test_exp_save_message(tmp_dir, mocked_dvc_repo):
         force=True,
         message="Custom message",
     )
+
+
+def test_no_scm_repo(tmp_dir, mocker):
+    dvc_repo = mocker.MagicMock()
+    dvc_repo.scm = NoSCM()
+
+    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
+        live = Live()
+        assert live._dvc_repo == dvc_repo
+
+        live = Live(save_dvc_exp=True)
+        assert live._save_dvc_exp is False


### PR DESCRIPTION
Ran into this trying on databricks. If I have a `--no-scm` repo, dvclive will fail because we assume the existence of a dvc repo means existence of a git repo and don't check whether `Live._dvc_repo.scm` is `Git` or `NoSCM`.
