### PR TITLE
docs: add `dev` extra to install command in contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,11 +57,11 @@ You need Python 3.8+.
    $ python -m venv .venv
    $ source .venv/bin/activate
 
-Install in editable mode:
+Install in editable mode including development dependencies:
 
 .. code:: console
 
-   $ pip install -e .
+   $ pip install -e .[dev]
 
 
 How to test the project

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,7 +61,7 @@ Install in editable mode including development dependencies:
 
 .. code:: console
 
-   $ pip install -e .[dev]
+   $ pip install -e .[tests]
 
 
 How to test the project


### PR DESCRIPTION
I've updated the contributing guide to instruct a contributor to install also the `dev` extra. Otherwise, `pytest` and all other development dependencies won't be available.

- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md)
  guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. &ndash; **n/a**