### PR TITLE
log_artifact: add cache option, only write to dvc.yaml if metadata ex…

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -413,10 +413,11 @@ class Live:
         path: StrPath,
         type: Optional[str] = None,  # noqa: A002
         name: Optional[str] = None,
-        desc: Optional[str] = None,  # noqa: ARG002
-        labels: Optional[List[str]] = None,  # noqa: ARG002
-        meta: Optional[Dict[str, Any]] = None,  # noqa: ARG002
+        desc: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+        meta: Optional[Dict[str, Any]] = None,
         copy: bool = False,
+        cache: bool = True,
     ):
         """Tracks a local file or directory with DVC"""
         if not isinstance(path, (str, Path)):
@@ -428,21 +429,24 @@ class Live:
             if copy:
                 path = clean_and_copy_into(path, self.artifacts_dir)
 
-            self.cache(path)
+            if cache:
+                self.cache(path)
 
-            name = name or Path(path).stem
-            if name_is_compatible(name):
-                self._artifacts[name] = {
-                    k: v
-                    for k, v in locals().items()
-                    if k in ("path", "type", "desc", "labels", "meta") and v is not None
-                }
-            else:
-                logger.warning(
-                    "Can't use '%s' as artifact name (ID)."
-                    " It will not be included in the `artifacts` section.",
-                    name,
-                )
+            if any((type, name, desc, labels, meta)):
+                name = name or Path(path).stem
+                if name_is_compatible(name):
+                    self._artifacts[name] = {
+                        k: v
+                        for k, v in locals().items()
+                        if k in ("path", "type", "desc", "labels", "meta")
+                        and v is not None
+                    }
+                else:
+                    logger.warning(
+                        "Can't use '%s' as artifact name (ID)."
+                        " It will not be included in the `artifacts` section.",
+                        name,
+                    )
 
     def cache(self, path):
         try:


### PR DESCRIPTION
Extracted from #613.

* Artifacts will only be annotated in `dvc.yaml:artifacts` if some metadata is provided (type, name, desc, labels, or meta). This is a breaking change, but I can't see how anyone is making use of this without any metadata since it won't be used by the model registry. It's needed in #613 so we can cache a whole directory of checkpoints without annotating the whole directory.
* Added `cache` kwarg to `log_artifact` (defaults to `True`) so that it's possible to annotate the artifact metadata without caching the object. It's needed in #613 so we can annotate the `best` artifact in `dvc.yaml` without re-caching (since it overlaps with the cached checkpoints directory).

There are probably workarounds for both in #613, but I think this flexibility to choose when to cache and when to annotate in `dvc.yaml` is useful. It also should close #572 ~~and #551~~ (edit: and partially address #551) since it decouples caching and annotation.