### PR TITLE
README: A more engaging code snippet ecample

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,34 @@ $ git commit -m "DVC init"
 
 ## Example code
 
-Copy the snippet below as a basic example of the API usage:
+Copy the snippet below into `train.py` for a basic API usage example:
 
 ```python
-# train.py
+import time
 import random
-import sys
+
 from dvclive import Live
 
+params = {"learning_rate": 0.002, "optimizer": "Adam", "epochs": 20}
+
 with Live(save_dvc_exp=True) as live:
-    epochs = int(sys.argv[1])
-    live.log_param("epochs", epochs)
-    for epoch in range(epochs):
-        live.log_metric("train/accuracy", epoch + random.random())
-        live.log_metric("train/loss", epochs - epoch - random.random())
-        live.log_metric("val/accuracy",epoch + random.random() )
-        live.log_metric("val/loss", epochs - epoch - random.random())
+
+    # log a parameters
+    for param in params:
+        live.log_param(param, params[param])
+
+    # simulate training
+    offset = random.uniform(0.0.2, 0.1)
+    for epoch in range(1, params["epochs"]):
+        fuzz = random.uniform(0.01, 0.1) 
+        accuracy = 1 - (2 ** - epoch) - fuzz - offset
+        loss = (2 ** - epoch) + fuzz + offset
+
+        # log metrics to studio
+        live.log_metric("accuracy", accuracy)
+        live.log_metric("loss", loss)
         live.next_step()
+        time.sleep(0.2)
 ```
 
 See [Integrations](https://dvc.org/doc/dvclive/ml-frameworks) for examples using
@@ -76,12 +87,13 @@ DVCLive alongside different ML Frameworks.
 
 ## Running
 
-Run couple of times passing different values:
+Run this a couple of times to simulate multiple experiments:
 
 ```console
-$ python train.py 5
-$ python train.py 5
-$ python train.py 7
+$ python train.py
+$ python train.py
+$ python train.py
+...
 ```
 
 ## Comparing

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ with Live(save_dvc_exp=True) as live:
     # simulate training
     offset = random.uniform(0.0.2, 0.1)
     for epoch in range(1, params["epochs"]):
-        fuzz = random.uniform(0.01, 0.1) 
+        fuzz = random.uniform(0.01, 0.1)
         accuracy = 1 - (2 ** - epoch) - fuzz - offset
         loss = (2 ** - epoch) + fuzz + offset
 


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/master/CONTRIBUTING.md)
  guide.

- [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


As discussed in an issues in [studio#6422](https://github.com/iterative/studio/issues/6422)) (private repo) - suggested some changes to this snippet:
copy-pasting motivation:

> Yes - a working snippet is what I was driving it.
> Looking at the snippet in the readme I suggest to consider updating maybe - that's why I looked at some competitors and compiled a new one before.
> 
> first order problem IMO is having a snippet that works out of the box
> 2nd order problem - polish how this snippet looks  - so it's short and clean and nice, but also interesting.
> things that bother me today a bit about the snippet from the [readme](https://github.com/iterative/dvclive/tree/main#example-code)(⚠️ : opinionated / style!):
> - direct access to `sys.argv` (ugly)
> - I can't run it "cleanly" -`python train.py` - fails in an ugly way (💭 mental mode - I'm just copy-pasting in "autopilot mental mode" to test studio - I don't want to have to make a decision about epoch parameter)
> - 4 metrics/plots - train/eval is redundant (the same, also "eval called "val" ? 😖 )
> - graphs aren't "interesting" to my taste (linear + noise):
>   <details><summary>screenshot</summary>
>     <img width="1465" alt="Screenshot 2023-07-09 at 23 47 40" src="https://github.com/iterative/studio/assets/18181802/5d043212-d54b-441d-8f57-fbb3c04e34f0">
>   </details>
>   that's a personal "peeve"  - it's not bad per-se, just that I saw an easy way to improve (from wandb, see below).
> - exp finishes too quickly - had to run several times to "catch" the "liveness" of the metrics
> 
> 

Graphs for new snippet
<details><summary>screenshot</summary>
  
<img width="1724" alt="252168487-e814ec47-8123-4f35-962a-b365f6c716f2" src="https://github.com/iterative/dvclive/assets/18181802/dd4a12fc-a474-4e62-8a51-713285f8a7d7">

</details>

wdyt about this instead of the existing one @daavoo?
