### PR TITLE
fix broken pytorch-lightning import

### DIFF
--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -22,7 +22,11 @@ except ImportError:
     from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
     from pytorch_lightning.loggers.logger import Logger, rank_zero_experiment
     from pytorch_lightning.utilities import rank_zero_only
-    from pytorch_lightning.utilities.logger import _scan_checkpoints
+
+    try:
+        from pytorch_lightning.utilities.logger import _scan_checkpoints
+    except ImportError:
+        from pytorch_lightning.loggers.utilities import _scan_checkpoints
 from torch import is_tensor
 
 from dvclive import Live


### PR DESCRIPTION
Per https://github.com/iterative/dvclive/issues/625#issuecomment-1678757747.

The current import works for `pytorch-lightning<2.0`. Added a nested try/except to work for `pytorch-lightning>2.0`. It's getting a bit ugly, but don't see a good reason not to support as many versions as possible for now.
