### PR TITLE
live.log_metric: Cast `nan` and `inf` to string.

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import os
 import shutil
 from pathlib import Path
@@ -295,12 +296,15 @@ class Live:
     def log_metric(
         self,
         name: str,
-        val: Union[int, float],
+        val: Union[int, float, str],
         timestamp: bool = False,
         plot: bool = True,
     ):
         if not Metric.could_log(val):
             raise InvalidDataTypeError(name, type(val))
+
+        if not isinstance(val, str) and (math.isnan(val) or math.isinf(val)):
+            val = str(val)
 
         if name in self._metrics:
             metric = self._metrics[name]

--- a/src/dvclive/plots/metric.py
+++ b/src/dvclive/plots/metric.py
@@ -14,7 +14,7 @@ class Metric(Data):
 
     @staticmethod
     def could_log(val: object) -> bool:
-        if isinstance(val, (int, float)):
+        if isinstance(val, (int, float, str)):
             return True
         if (
             val.__class__.__module__ == "numpy"

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -1,5 +1,6 @@
 # ruff: noqa: SLF001
 import base64
+import math
 import os
 from pathlib import Path
 
@@ -21,7 +22,11 @@ def _cast_to_numbers(datapoints):
             elif k == "timestamp":
                 continue
             else:
-                datapoint[k] = float(v)
+                float_v = float(v)
+                if math.isnan(float_v) or math.isinf(float_v):
+                    datapoint[k] = str(v)
+                else:
+                    datapoint[k] = float_v
     return datapoints
 
 

--- a/tests/test_log_metric.py
+++ b/tests/test_log_metric.py
@@ -1,0 +1,22 @@
+import math
+
+import numpy as np
+import pytest
+
+from dvclive import Live
+
+
+@pytest.mark.parametrize(
+    ("val"),
+    [math.inf, math.nan, np.nan, np.inf],
+)
+def test_log_metric_inf_nan(tmp_dir, val):
+    with Live() as live:
+        live.log_metric("metric", val)
+    assert live.summary["metric"] == str(val)
+
+
+def test_log_metic_str(tmp_dir):
+    with Live() as live:
+        live.log_metric("metric", "foo")
+    assert live.summary["metric"] == "foo"

--- a/tests/test_log_metric.py
+++ b/tests/test_log_metric.py
@@ -4,6 +4,18 @@ import numpy as np
 import pytest
 
 from dvclive import Live
+from dvclive.error import InvalidDataTypeError
+
+
+@pytest.mark.parametrize("invalid_type", [{0: 1}, [0, 1], (0, 1)])
+def test_invalid_metric_type(tmp_dir, invalid_type):
+    dvclive = Live()
+
+    with pytest.raises(
+        InvalidDataTypeError,
+        match=f"Data 'm' has not supported type {type(invalid_type)}",
+    ):
+        dvclive.log_metric("m", invalid_type)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,7 @@ import pytest
 from PIL import Image
 
 from dvclive import Live, env
-from dvclive.error import InvalidDataTypeError, InvalidParameterTypeError
+from dvclive.error import InvalidParameterTypeError
 from dvclive.plots import Metric
 from dvclive.serialize import load_yaml
 from dvclive.utils import parse_metrics, parse_tsv
@@ -270,17 +270,6 @@ def test_log_reset_with_set_step(tmp_dir):
     assert read_history(dvclive, "val_m") == ([0, 1, 2], [1, 1, 1])
     assert read_latest(dvclive, "train_m") == (2, 1)
     assert read_latest(dvclive, "val_m") == (2, 1)
-
-
-@pytest.mark.parametrize("invalid_type", [{0: 1}, [0, 1], "foo", (0, 1)])
-def test_invalid_metric_type(tmp_dir, invalid_type):
-    dvclive = Live()
-
-    with pytest.raises(
-        InvalidDataTypeError,
-        match=f"Data 'm' has not supported type {type(invalid_type)}",
-    ):
-        dvclive.log_metric("m", invalid_type)
 
 
 def test_get_step_resume(tmp_dir):


### PR DESCRIPTION
- Support string metrics (forgot to support them when DVC added support)
- Don't recast to float when sending to Studio.

Closes https://github.com/iterative/studio-support/issues/93

I have manually tested end to end against Studio sending inf/nan from `math`, `numpy`, and `torch`. 
The Vega plots in the frontend appear to handle just fine datapoints with those values (the datapoint is skipped).
