### PR TITLE
warn on log_artifact when no repo

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -459,6 +459,11 @@ class Live:
                         " It will not be included in the `artifacts` section.",
                         name,
                     )
+        else:
+            logger.warning(
+                "A DVC repo is required to log artifacts. "
+                f"Skipping `log_artifact({path})`."
+            )
 
     @catch_and_warn(DvcException, logger)
     def cache(self, path):

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -285,3 +285,13 @@ def test_log_artifact_inside_exp_subdir(tmp_dir, mocker, dvc_repo):
     )
     logger.warning.assert_called_with(msg)
     spy.assert_called_once()
+
+
+def test_log_artifact_no_repo(tmp_dir, mocker):
+    logger = mocker.patch("dvclive.live.logger")
+    (tmp_dir / "data").touch()
+    live = Live()
+    live.log_artifact("data")
+    logger.warning.assert_called_with(
+        "A DVC repo is required to log artifacts. Skipping `log_artifact(data)`."
+    )


### PR DESCRIPTION
Context: https://iterativeai.slack.com/archives/CB41NAL8H/p1693333001773389

tldr `log_artifact` is a noop without a DVC repo, so we should warn in this scenario.