### PR TITLE
pyproject: add custom pytest markers definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,10 @@ line_length = 88
 
 [tool.pytest.ini_options]
 addopts = "-ra"
+markers = """
+    vscode: mark a test that verifies behavior that VS Code relies on
+    studio: mark a test that verifies behavior that Studio relies on
+"""
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst)
  guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

---

Minor: gets rid of warnings of the form 
```
tests/test_studio.py:197
  /dvclive/tests/test_studio.py:197: PytestUnknownMarkWarning: Unknown pytest.mark.studio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.studio()
```
from the `pytest` logs.