### PR TITLE
pytest: fix mocker as context manager and setenv test warnings

### DIFF
--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -157,9 +157,9 @@ def test_exp_save_skip_on_env_vars(tmp_dir, monkeypatch, mocker):
     monkeypatch.setenv(DVC_EXP_BASELINE_REV, "foo")
     monkeypatch.setenv(DVC_EXP_NAME, "bar")
 
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=None):
-        live = Live(save_dvc_exp=True)
-        live.end()
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=None)
+    live = Live(save_dvc_exp=True)
+    live.end()
 
     assert live._dvc_repo is None
     assert live._baseline_rev == "foo"
@@ -176,12 +176,12 @@ def test_exp_save_run_on_dvc_repro(tmp_dir, mocker):
     dvc_repo.scm.get_ref.return_value = None
     dvc_repo.scm.no_commits = False
     dvc_repo.config = {}
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
-        live = Live(save_dvc_exp=True)
-        assert live._save_dvc_exp
-        assert live._baseline_rev is not None
-        assert live._exp_name is not None
-        live.end()
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+    live = Live(save_dvc_exp=True)
+    assert live._save_dvc_exp
+    assert live._baseline_rev is not None
+    assert live._exp_name is not None
+    live.end()
 
     dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name, include_untracked=[live.dir], force=True, message=None
@@ -218,9 +218,9 @@ def test_exp_save_with_dvc_files(tmp_dir, mocker):
     dvc_repo.scm.no_commits = False
     dvc_repo.config = {}
 
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
-        live = Live(save_dvc_exp=True)
-        live.end()
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+    live = Live(save_dvc_exp=True)
+    live.end()
 
     dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name, include_untracked=[live.dir], force=True, message=None
@@ -316,9 +316,9 @@ def test_no_scm_repo(tmp_dir, mocker):
     dvc_repo = mocker.MagicMock()
     dvc_repo.scm = NoSCM()
 
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):
-        live = Live()
-        assert live._dvc_repo == dvc_repo
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+    live = Live()
+    assert live._dvc_repo == dvc_repo
 
-        live = Live(save_dvc_exp=True)
-        assert live._save_dvc_exp is False
+    live = Live(save_dvc_exp=True)
+    assert live._save_dvc_exp is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -226,7 +226,7 @@ def test_resume_on_first_init(tmp_dir):
 def test_resume_env_var(tmp_dir, monkeypatch):
     assert not Live()._resume
 
-    monkeypatch.setenv(env.DVCLIVE_RESUME, True)
+    monkeypatch.setenv(env.DVCLIVE_RESUME, "true")
     assert Live()._resume
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -122,7 +122,7 @@ def test_make_report_open(tmp_dir, mocker, monkeypatch):
 
     assert not mocked_open.called
 
-    monkeypatch.setenv(DVCLIVE_OPEN, True)
+    monkeypatch.setenv(DVCLIVE_OPEN, "true")
 
     live = Live()
     live.log_sklearn_plot("confusion_matrix", [0, 0, 1, 1], [1, 0, 0, 1])

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -19,7 +19,7 @@ def test_vscode_dvclive_step_completed_signal_file(
 
     if dvc_root:
         cwd = tmp_dir / ".dvc" / "tmp" / "exps" / "asdasasf"
-        monkeypatch.setenv(env.DVC_ROOT, tmp_dir)
+        monkeypatch.setenv(env.DVC_ROOT, tmp_dir.as_posix())
         (cwd / ".dvc").mkdir(parents=True)
 
     assert not os.path.exists(signal_file)
@@ -30,28 +30,28 @@ def test_vscode_dvclive_step_completed_signal_file(
     dvc_repo.scm.get_rev.return_value = "current_rev"
     dvc_repo.scm.get_ref.return_value = None
     dvc_repo.scm.no_commits = False
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo), mocker.patch(
-        "dvclive.live.os.getpid", return_value=test_pid
-    ):
-        dvclive = Live(save_dvc_exp=True)
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+    mocker.patch("dvclive.live.os.getpid", return_value=test_pid)
+
+    dvclive = Live(save_dvc_exp=True)
+    assert not os.path.exists(signal_file)
+    dvclive.next_step()
+    assert dvclive.step == 1
+
+    if dvc_root:
+        assert os.path.exists(signal_file)
+        with open(signal_file, encoding="utf-8") as f:
+            assert json.load(f) == {"pid": test_pid, "step": 0}
+
+    else:
         assert not os.path.exists(signal_file)
-        dvclive.next_step()
-        assert dvclive.step == 1
 
-        if dvc_root:
-            assert os.path.exists(signal_file)
-            with open(signal_file, encoding="utf-8") as f:
-                assert json.load(f) == {"pid": test_pid, "step": 0}
+    dvclive.next_step()
+    assert dvclive.step == 2
 
-        else:
-            assert not os.path.exists(signal_file)
-
-        dvclive.next_step()
-        assert dvclive.step == 2
-
-        if dvc_root:
-            with open(signal_file, encoding="utf-8") as f:
-                assert json.load(f) == {"pid": test_pid, "step": 1}
+    if dvc_root:
+        with open(signal_file, encoding="utf-8") as f:
+            assert json.load(f) == {"pid": test_pid, "step": 1}
 
     dvclive.end()
 
@@ -75,10 +75,10 @@ def test_vscode_dvclive_only_signal_file(tmp_dir, dvc_root, mocker):
     dvc_repo.scm.get_rev.return_value = "current_rev"
     dvc_repo.scm.get_ref.return_value = None
     dvc_repo.scm.no_commits = False
-    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo), mocker.patch(
-        "dvclive.live.os.getpid", return_value=test_pid
-    ):
-        dvclive = Live(save_dvc_exp=True)
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo)
+    mocker.patch("dvclive.live.os.getpid", return_value=test_pid)
+
+    dvclive = Live(save_dvc_exp=True)
 
     if dvc_root:
         assert os.path.exists(signal_file)


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst)
  guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

-----

Fixes issue of the format:

```
  /dvclive/tests/test_dvc.py:160: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=None):
```
& 

```
  /dvclive/tests/test_main.py:229: PytestWarning: Value of environment variable DVCLIVE_RESUME type should be str, but got True (type: bool); converted to str implicitly
    monkeypatch.setenv(env.DVCLIVE_RESUME, True)
```

## Result of `pytest -v tests --ignore=tests/test_frameworks`:

### Before

<details> 
 <summary>Log</summary>

```
================================================================================================================================================ warnings summary ================================================================================================================================================
tests/test_dvc.py::test_exp_save_skip_on_env_vars
  /dvclive/tests/test_dvc.py:160: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=None):

tests/test_dvc.py::test_exp_save_run_on_dvc_repro
  /dvclive/tests/test_dvc.py:179: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):

tests/test_dvc.py::test_exp_save_with_dvc_files
  /dvclive/tests/test_dvc.py:221: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):

tests/test_dvc.py::test_no_scm_repo
  /dvclive/tests/test_dvc.py:319: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo):

tests/test_main.py::test_resume_env_var
  /dvclive/tests/test_main.py:229: PytestWarning: Value of environment variable DVCLIVE_RESUME type should be str, but got True (type: bool); converted to str implicitly
    monkeypatch.setenv(env.DVCLIVE_RESUME, True)

tests/test_report.py::test_make_report_open
  /dvclive/tests/test_report.py:125: PytestWarning: Value of environment variable DVCLIVE_OPEN type should be str, but got True (type: bool); converted to str implicitly
    monkeypatch.setenv(DVCLIVE_OPEN, True)

tests/test_vscode.py::test_vscode_dvclive_step_completed_signal_file[True]
  /dvclive/tests/test_vscode.py:22: PytestWarning: Value of environment variable DVC_ROOT type should be str, but got PosixPath('/private/var/folders/sb/fqcw44jd19nfrhl_9lz_81d80000gn/T/pytest-of/pytest-138/test_vscode_dvclive_step_compl0') (type: PosixPath); converted to str implicitly
    monkeypatch.setenv(env.DVC_ROOT, tmp_dir)

tests/test_vscode.py::test_vscode_dvclive_step_completed_signal_file[True]
tests/test_vscode.py::test_vscode_dvclive_step_completed_signal_file[False]
  /dvclive/tests/test_vscode.py:33: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo), mocker.patch(

tests/test_vscode.py::test_vscode_dvclive_only_signal_file[True]
tests/test_vscode.py::test_vscode_dvclive_only_signal_file[False]
  /dvclive/tests/test_vscode.py:78: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    with mocker.patch("dvclive.live.get_dvc_repo", return_value=dvc_repo), mocker.patch(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

Results (4.52s):
     174 passed
```

</details>

### After

```
Results (4.75s):
     174 passed
```