### PR TITLE
live: warn when DVC_ROOT is set but DVC_EXP_BASELINE_REV is not

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -186,6 +186,9 @@ class Live:
                 self._save_dvc_exp = False
         elif os.getenv(env.DVC_ROOT, None):
             # `dvc repro` execution
+            if self._save_dvc_exp:
+                logger.info("Ignoring `save_dvc_exp` because `dvc repro` is running")
+                self._save_dvc_exp = False
             logger.warning(
                 "Some DVCLive features are unsupported in `dvc repro`."
                 "\nTo use DVCLive with a DVC Pipeline, run it with `dvc exp run`."

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -135,15 +135,7 @@ class Live:
     def _init_dvc(self):
         from dvc.scm import NoSCM
 
-        if os.getenv(env.DVC_EXP_BASELINE_REV, None):
-            # `dvc exp` execution
-            self._baseline_rev = os.getenv(env.DVC_EXP_BASELINE_REV, "")
-            self._exp_name = os.getenv(env.DVC_EXP_NAME, "")
-            self._inside_dvc_exp = True
-            if self._save_dvc_exp:
-                logger.info("Ignoring `save_dvc_exp` because `dvc exp run` is running")
-                self._save_dvc_exp = False
-
+        self._init_dvc_pipeline()
         self._dvc_repo = get_dvc_repo()
 
         dvc_logger = logging.getLogger("dvc")
@@ -182,6 +174,22 @@ class Live:
             self._exp_name = get_random_exp_name(self._dvc_repo.scm, self._baseline_rev)
             mark_dvclive_only_started(self._exp_name)
             self._include_untracked.append(self.dir)
+
+    def _init_dvc_pipeline(self):
+        if os.getenv(env.DVC_EXP_BASELINE_REV, None):
+            # `dvc exp` execution
+            self._baseline_rev = os.getenv(env.DVC_EXP_BASELINE_REV, "")
+            self._exp_name = os.getenv(env.DVC_EXP_NAME, "")
+            self._inside_dvc_exp = True
+            if self._save_dvc_exp:
+                logger.info("Ignoring `save_dvc_exp` because `dvc exp run` is running")
+                self._save_dvc_exp = False
+        elif os.getenv(env.DVC_ROOT, None):
+            # `dvc repro` execution
+            logger.warning(
+                "Some DVCLive features are unsupported in `dvc repro`."
+                "\nTo use DVCLive with a DVC Pipeline, run it with `dvc exp run`."
+            )
 
     def _init_studio(self):
         self._dvc_studio_config = get_dvc_studio_config(self)

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -10,7 +10,7 @@ from scmrepo.git import Git
 
 from dvclive import Live
 from dvclive.dvc import get_dvc_repo, make_dvcyaml
-from dvclive.env import DVC_EXP_BASELINE_REV, DVC_EXP_NAME
+from dvclive.env import DVC_EXP_BASELINE_REV, DVC_EXP_NAME, DVC_ROOT
 from dvclive.serialize import load_yaml
 
 YAML_LOADER = YAML(typ="safe")
@@ -322,3 +322,10 @@ def test_no_scm_repo(tmp_dir, mocker):
 
     live = Live(save_dvc_exp=True)
     assert live._save_dvc_exp is False
+
+
+def test_dvc_repro(tmp_dir, monkeypatch, mocker):
+    monkeypatch.setenv(DVC_ROOT, "root")
+    mocker.patch("dvclive.live.get_dvc_repo", return_value=None)
+    live = Live(save_dvc_exp=True)
+    assert not live._save_dvc_exp


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst)
  guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close https://github.com/iterative/dvclive/issues/670 (requires https://github.com/iterative/dvc/pull/9879)

- Generates a warning message when dvclive is init'ed inside a `dvc repro` pipeline stage (but not when inside `dvc exp run`)

With https://github.com/iterative/lstm_seq2seq:
```
$ dvc repro
Running stage 'download':
...
Running stage 'train':
> python train.py
Number of samples: 10000
Number of unique input tokens: 72
Number of unique output tokens: 101
Max sequence length for inputs: 117
Max sequence length for outputs: 149
WARNING:dvclive:Some DVCLive features are unsupported in `dvc repro`.
To use DVCLive with a DVC Pipeline, run it with `dvc exp run`.
GPU available: True (mps), used: True
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
HPU available: False, using: 0 HPUs
...
```