### PR TITLE
log_artifact: Use name validation from GTO.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dvc>=3.22.0",
+    "dvc>3.22.1",
     "dvc-render>=0.6.0,<1.0",
     "dvc-studio-client>=0.15.0,<1",
     "funcy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dvc>3.22.1",
+    "dvc>=3.22.1",
     "dvc-render>=0.6.0,<1.0",
     "dvc-studio-client>=0.15.0,<1",
     "funcy",
+    "gto",
     "ruamel.yaml",
     "scmrepo",
 ]

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -461,7 +461,8 @@ class Live:
             raise InvalidDataTypeError(path, type(path))
 
         if self._dvc_repo is not None:
-            from dvc.repo.artifacts import name_is_compatible
+            from gto.constants import assert_name_is_valid
+            from gto.exceptions import ValidationError
 
             if copy:
                 path = clean_and_copy_into(path, self.artifacts_dir)
@@ -471,14 +472,15 @@ class Live:
 
             if any((type, name, desc, labels, meta)):
                 name = name or Path(path).stem
-                if name_is_compatible(name):
+                try:
+                    assert_name_is_valid(name)
                     self._artifacts[name] = {
                         k: v
                         for k, v in locals().items()
                         if k in ("path", "type", "desc", "labels", "meta")
                         and v is not None
                     }
-                else:
+                except ValidationError:
                     logger.warning(
                         "Can't use '%s' as artifact name (ID)."
                         " It will not be included in the `artifacts` section.",


### PR DESCRIPTION
The function we were using from `dvc.repo.artifacts` was dropped in https://github.com/iterative/dvc/pull/9770

deps: bump  "dvc>=3.22.1"
deps: Add `gto`