### PR TITLE
codespell: disable for .ipynb files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,10 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies: ["tomli"]
+        exclude: >
+            (?x)^(
+                .*\.ipynb
+            )$
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/examples/DVCLive-HuggingFace.ipynb
+++ b/examples/DVCLive-HuggingFace.ipynb
@@ -66,7 +66,7 @@
     "#### Loading the dataset\n",
     "\n",
     "We will use the [imdb](https://huggingface.co/datasets/imdb) Large Movie Review Dataset. This is a dataset for binary\n",
-    "sentiment classification containing a set of 25K movie reviews for traning and\n",
+    "sentiment classification containing a set of 25K movie reviews for training and\n",
     "25K for testing.\n"
    ]
   },


### PR DESCRIPTION
Per https://github.com/iterative/dvclive/pull/723#issuecomment-1766175609, codespell may have issues checking jupyter notebooks. It did catch one valid issue, but I think dealing with false positives for ipynb files makes it not worth it.
