### PR TITLE
dvcyaml: write to cwd instead of git root

### DIFF
--- a/tests/frameworks/test_lightning.py
+++ b/tests/frameworks/test_lightning.py
@@ -155,7 +155,7 @@ def test_lightning_default_dir(tmp_dir):
     assert os.path.exists("dvclive")
 
 
-def test_lightning_kwargs(tmp_dir):
+def test_lightning_kwargs_e2e(tmp_dir):
     model = LitXOR()
     # Handle kwargs passed to Live.
     dvclive_logger = DVCLiveLogger(
@@ -301,6 +301,15 @@ def test_lightning_force_init(tmp_dir, mocker):
     init = mocker.spy(Live, "__init__")
     DVCLiveLogger()
     init.assert_not_called()
+
+
+def test_lightning_kwargs(tmp_dir, mocker):
+    dvclive_logger = DVCLiveLogger(save_dvc_exp=False)
+    assert dvclive_logger.experiment._save_dvc_exp is False
+
+    live = Live(save_dvc_exp=False)
+    dvclive_logger = DVCLiveLogger(experiment=live)
+    assert dvclive_logger.experiment._save_dvc_exp is False
 
 
 # LightningCLI tests

--- a/tests/frameworks/test_lightning.py
+++ b/tests/frameworks/test_lightning.py
@@ -155,7 +155,7 @@ def test_lightning_default_dir(tmp_dir):
     assert os.path.exists("dvclive")
 
 
-def test_lightning_kwargs_e2e(tmp_dir):
+def test_lightning_kwargs(tmp_dir):
     model = LitXOR()
     # Handle kwargs passed to Live.
     dvclive_logger = DVCLiveLogger(
@@ -301,15 +301,6 @@ def test_lightning_force_init(tmp_dir, mocker):
     init = mocker.spy(Live, "__init__")
     DVCLiveLogger()
     init.assert_not_called()
-
-
-def test_lightning_kwargs(tmp_dir, mocker):
-    dvclive_logger = DVCLiveLogger(save_dvc_exp=False)
-    assert dvclive_logger.experiment._save_dvc_exp is False
-
-    live = Live(save_dvc_exp=False)
-    dvclive_logger = DVCLiveLogger(experiment=live)
-    assert dvclive_logger.experiment._save_dvc_exp is False
 
 
 # LightningCLI tests

--- a/tests/test_dvc.py
+++ b/tests/test_dvc.py
@@ -34,7 +34,7 @@ def test_exp_save_on_end(tmp_dir, save, mocked_dvc_repo):
         assert live._exp_name is not None
         mocked_dvc_repo.experiments.save.assert_called_with(
             name=live._exp_name,
-            include_untracked=[live.dir, str(tmp_dir / "dvc.yaml")],
+            include_untracked=[live.dir, "dvc.yaml"],
             force=True,
             message=None,
         )
@@ -79,7 +79,7 @@ def test_exp_save_run_on_dvc_repro(tmp_dir, mocker):
 
     dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name,
-        include_untracked=[live.dir, str(tmp_dir / "dvc.yaml")],
+        include_untracked=[live.dir, "dvc.yaml"],
         force=True,
         message=None,
     )
@@ -102,7 +102,7 @@ def test_exp_save_with_dvc_files(tmp_dir, mocker):
 
     dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name,
-        include_untracked=[live.dir, str(tmp_dir / "dvc.yaml")],
+        include_untracked=[live.dir, "dvc.yaml"],
         force=True,
         message=None,
     )
@@ -175,7 +175,7 @@ def test_exp_save_message(tmp_dir, mocked_dvc_repo):
     live.end()
     mocked_dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name,
-        include_untracked=[live.dir, str(tmp_dir / "dvc.yaml")],
+        include_untracked=[live.dir, "dvc.yaml"],
         force=True,
         message="Custom message",
     )
@@ -186,7 +186,7 @@ def test_exp_save_name(tmp_dir, mocked_dvc_repo):
     live.end()
     mocked_dvc_repo.experiments.save.assert_called_with(
         name="custom-name",
-        include_untracked=[live.dir, str(tmp_dir / "dvc.yaml")],
+        include_untracked=[live.dir, "dvc.yaml"],
         force=True,
         message=None,
     )

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -58,7 +58,7 @@ def test_log_artifact_with_save_dvc_exp(tmp_dir, mocker, mocked_dvc_repo):
         live.log_artifact("data")
     mocked_dvc_repo.experiments.save.assert_called_with(
         name=live._exp_name,
-        include_untracked=[live.dir, "data", ".gitignore", str(tmp_dir / "dvc.yaml")],
+        include_untracked=[live.dir, "data", ".gitignore", "dvc.yaml"],
         force=True,
         message=None,
     )

--- a/tests/test_make_dvcyaml.py
+++ b/tests/test_make_dvcyaml.py
@@ -440,18 +440,33 @@ def test_make_dvcyaml(tmp_dir, mocked_dvc_repo, dvcyaml):
 
 
 def test_make_dvcyaml_no_repo(tmp_dir, mocker):
-    logger = mocker.patch("dvclive.live.logger")
     dvclive = Live("logs")
     dvclive.make_dvcyaml()
 
-    assert not os.path.exists("dvc.yaml")
-    assert not dvclive.dvc_file
-    logger.warning.assert_any_call(
-        "Can't infer dvcyaml path without a DVC repo. "
-        "`dvc.yaml` file will not be written."
-    )
+    assert os.path.exists("dvc.yaml")
 
 
 def test_make_dvcyaml_invalid(tmp_dir, mocker):
     with pytest.raises(InvalidDvcyamlError):
         Live("logs", dvcyaml="invalid")
+
+
+def test_make_dvcyaml_on_end(tmp_dir, mocker):
+    dvclive = Live("logs")
+    dvclive.end()
+
+    assert os.path.exists("dvc.yaml")
+
+
+def test_make_dvcyaml_false(tmp_dir, mocker):
+    dvclive = Live("logs", dvcyaml=False)
+    dvclive.end()
+
+    assert not os.path.exists("dvc.yaml")
+
+
+def test_make_dvcyaml_none(tmp_dir, mocker):
+    dvclive = Live("logs", dvcyaml=None)
+    dvclive.end()
+
+    assert not os.path.exists("dvc.yaml")


### PR DESCRIPTION
Instead of defaulting to the git root for dvc.yaml, use the current path. This is technically a breaking change, but it simplifies the dvc.yaml logic and should have the same behavior for most users.

Rationale for this change:
* Avoids unnecessary git logic that can cause [unexpected behavior](https://iterativeai.slack.com/archives/C03JS2V4MQU/p1698052870762279)
* More consistent with dvc commands (for example, `dvc stage add` writes `dvc.yaml` in the current directory, not the git root)
* Simpler code