### PR TITLE
post data to studio on end

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -569,6 +569,9 @@ class Live:
 
         self.save_dvc_exp()
 
+        # Post any data that hasn't been sent
+        self.post_to_studio("data")
+        # Mark experiment as done
         self.post_to_studio("done")
 
         cleanup_dvclive_step_completed()

--- a/tests/test_post_to_studio.py
+++ b/tests/test_post_to_studio.py
@@ -180,6 +180,7 @@ def test_post_to_studio_dvc_studio_config(
     monkeypatch.setenv(DVC_EXP_BASELINE_REV, "f" * 40)
     monkeypatch.setenv(DVC_EXP_NAME, "bar")
     monkeypatch.setenv(DVC_ROOT, tmp_dir)
+    monkeypatch.delenv(DVC_STUDIO_TOKEN)
 
     mocked_dvc_repo.config = {"studio": {"token": "token"}}
 
@@ -187,7 +188,7 @@ def test_post_to_studio_dvc_studio_config(
         live.log_metric("foo", 1)
         live.next_step()
 
-    assert mocked_post.call_count == 4
+    assert mocked_post.call_args.kwargs["headers"]["Authorization"] == "token token"
 
 
 @pytest.mark.studio()


### PR DESCRIPTION
Before we only post the `done` event during `live.end()`, which doesn't include any data. We should also be posting a `data` event before that to make sure the latest data is also sent.
