### PR TITLE
fix: Improve safety of logging images with implicit formats

### DIFF
--- a/src/dvclive/error.py
+++ b/src/dvclive/error.py
@@ -17,6 +17,12 @@ class InvalidDvcyamlError(DvcLiveError):
         super().__init__("`dvcyaml` path must have filename 'dvc.yaml'")
 
 
+class InvalidImageNameError(DvcLiveError):
+    def __init__(self, name):
+        self.name = name
+        super().__init__(f"Cannot log image with name '{name}'")
+
+
 class InvalidPlotTypeError(DvcLiveError):
     def __init__(self, name):
         from .plots import SKLEARN_PLOTS

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -379,12 +379,12 @@ class Live:
 
         # If the provided image name does not have a format on it,
         # try to infer the format from PIL Image.
-        if len(name.split(".")) <= 1:
-            if (
-                isinstance_without_import(val, "PIL.Image", "Image")
-                and f".{str(val.format).lower()}" in Image.suffixes
-            ):
-                name = f"{name}.{str(val.format).lower()}"
+        if (
+            len(name.split(".")) <= 1
+            and isinstance_without_import(val, "PIL.Image", "Image")
+            and f".{str(val.format).lower()}" in Image.suffixes
+        ):
+            name = f"{name}.{str(val.format).lower()}"
 
         # See if the image format and image name are valid
         if not Image.could_log(name, val):

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -371,9 +371,7 @@ class Live:
         logger.debug(f"Logged {name}: {val}")
 
     def log_image(self, name: str, val):
-        if not Image.could_log(val):
-            raise InvalidDataTypeError(name, type(val))
-
+        # If we're given a path, try loading the image first. This might error out.
         if isinstance(val, (str, Path)):
             from PIL import Image as ImagePIL
 
@@ -387,6 +385,10 @@ class Live:
                 and f".{str(val.format).lower()}" in Image.suffixes
             ):
                 name = f"{name}.{str(val.format).lower()}"
+
+        # See if the image format and image name are valid
+        if not Image.could_log(name, val):
+            raise InvalidDataTypeError(name, type(val))
 
         if name in self._images:
             image = self._images[name]

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -37,6 +37,7 @@ from .utils import (
     clean_and_copy_into,
     env2bool,
     inside_notebook,
+    isinstance_without_import,
     matplotlib_installed,
     open_file_in_browser,
 )
@@ -377,6 +378,15 @@ class Live:
             from PIL import Image as ImagePIL
 
             val = ImagePIL.open(val)
+
+        # If the provided image name does not have a format on it,
+        # try to infer the format from PIL Image.
+        if len(name.split(".")) <= 1:
+            if (
+                isinstance_without_import(val, "PIL.Image", "Image")
+                and f".{str(val.format).lower()}" in Image.suffixes
+            ):
+                name = f"{name}.{str(val.format).lower()}"
 
         if name in self._images:
             image = self._images[name]

--- a/src/dvclive/plots/image.py
+++ b/src/dvclive/plots/image.py
@@ -16,18 +16,21 @@ class Image(Data):
         return _path
 
     @staticmethod
-    def could_log(val: object) -> bool:
+    def could_log(name: str, val: object) -> bool:
         acceptable = {
             ("numpy", "ndarray"),
             ("matplotlib.figure", "Figure"),
             ("PIL.Image", "Image"),
         }
+
+        supported_format = False
         for cls in type(val).mro():
             if any(isinstance_without_import(val, *cls) for cls in acceptable):
-                return True
+                supported_format = True
         if isinstance(val, (PurePath, str)):
-            return True
-        return False
+            supported_format = True
+
+        return supported_format and f".{name.split('.')[-1]}" in Image.suffixes
 
     def dump(self, val, **kwargs) -> None:  # noqa: ARG002
         if isinstance_without_import(val, "numpy", "ndarray"):

--- a/src/dvclive/plots/image.py
+++ b/src/dvclive/plots/image.py
@@ -7,7 +7,7 @@ from .base import Data
 
 class Image(Data):
     suffixes = (".jpg", ".jpeg", ".gif", ".png")
-    subfolder: str = "images"
+    subfolder = "images"
 
     @property
     def output_path(self) -> Path:
@@ -16,21 +16,18 @@ class Image(Data):
         return _path
 
     @staticmethod
-    def could_log(name: str, val: object) -> bool:
+    def could_log(val: object) -> bool:
         acceptable = {
             ("numpy", "ndarray"),
             ("matplotlib.figure", "Figure"),
             ("PIL.Image", "Image"),
         }
-
-        supported_format = False
         for cls in type(val).mro():
             if any(isinstance_without_import(val, *cls) for cls in acceptable):
-                supported_format = True
+                return True
         if isinstance(val, (PurePath, str)):
-            supported_format = True
-
-        return supported_format and f".{name.split('.')[-1]}" in Image.suffixes
+            return True
+        return False
 
     def dump(self, val, **kwargs) -> None:  # noqa: ARG002
         if isinstance_without_import(val, "numpy", "ndarray"):

--- a/src/dvclive/plots/image.py
+++ b/src/dvclive/plots/image.py
@@ -7,7 +7,7 @@ from .base import Data
 
 class Image(Data):
     suffixes = (".jpg", ".jpeg", ".gif", ".png")
-    subfolder = "images"
+    subfolder: str = "images"
 
     @property
     def output_path(self) -> Path:

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -4,6 +4,7 @@ import pytest
 from PIL import Image
 
 from dvclive import Live
+from dvclive.error import InvalidDataTypeError
 from dvclive.plots import Image as LiveImage
 
 
@@ -27,7 +28,7 @@ def test_pil(tmp_dir):
 def test_pil_omitting_extension_doesnt_save_without_valid_format(tmp_dir):
     live = Live()
     img = Image.new("RGB", (10, 10), (250, 250, 250))
-    with pytest.raises(ValueError, match="unknown file extension"):
+    with pytest.raises(InvalidDataTypeError, match="has not supported type"):
         live.log_image("whoops", img)
 
 
@@ -50,7 +51,7 @@ def test_pil_omitting_extension_sets_the_format_if_path_given(tmp_dir):
 def test_invalid_extension(tmp_dir):
     live = Live()
     img = Image.new("RGB", (10, 10), (250, 250, 250))
-    with pytest.raises(ValueError, match="unknown file extension"):
+    with pytest.raises(InvalidDataTypeError, match="has not supported type"):
         live.log_image("image.foo", img)
 
 

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -24,6 +24,29 @@ def test_pil(tmp_dir):
     assert (tmp_dir / live.plots_dir / LiveImage.subfolder / "image.png").exists()
 
 
+def test_pil_omitting_extension_doesnt_save_without_valid_format(tmp_dir):
+    live = Live()
+    img = Image.new("RGB", (10, 10), (250, 250, 250))
+    with pytest.raises(ValueError, match="unknown file extension"):
+        live.log_image("whoops", img)
+
+
+def test_pil_omitting_extension_sets_the_format_if_path_given(tmp_dir):
+    live = Live()
+    img = Image.new("RGB", (10, 10), (250, 250, 250))
+
+    # Save it first, we'll reload it and pass it's path to log_image again
+    live.log_image("saved_with_format.png", img)
+
+    # Now try saving without explicit format and check if the format is set correctly.
+    live.log_image(
+        "whoops",
+        (tmp_dir / live.plots_dir / LiveImage.subfolder / "saved_with_format.png"),
+    )
+
+    assert (tmp_dir / live.plots_dir / LiveImage.subfolder / "whoops.png").exists()
+
+
 def test_invalid_extension(tmp_dir):
     live = Live()
     img = Image.new("RGB", (10, 10), (250, 250, 250))

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -4,7 +4,7 @@ import pytest
 from PIL import Image
 
 from dvclive import Live
-from dvclive.error import InvalidDataTypeError
+from dvclive.error import InvalidImageNameError
 from dvclive.plots import Image as LiveImage
 
 
@@ -28,7 +28,9 @@ def test_pil(tmp_dir):
 def test_pil_omitting_extension_doesnt_save_without_valid_format(tmp_dir):
     live = Live()
     img = Image.new("RGB", (10, 10), (250, 250, 250))
-    with pytest.raises(InvalidDataTypeError, match="has not supported type"):
+    with pytest.raises(
+        InvalidImageNameError, match="Cannot log image with name 'whoops'"
+    ):
         live.log_image("whoops", img)
 
 
@@ -51,7 +53,9 @@ def test_pil_omitting_extension_sets_the_format_if_path_given(tmp_dir):
 def test_invalid_extension(tmp_dir):
     live = Live()
     img = Image.new("RGB", (10, 10), (250, 250, 250))
-    with pytest.raises(InvalidDataTypeError, match="has not supported type"):
+    with pytest.raises(
+        InvalidImageNameError, match="Cannot log image with name 'image.foo'"
+    ):
         live.log_image("image.foo", img)
 
 


### PR DESCRIPTION
## Summary

This pull request makes it so:
- If `live.log_image` is called without image format in the `name`, we will try to infer the format from the image
- If we could not infer the format, we will raise an error message early in `could_log` instead of falling through to `PIL.Image.save`

Closes #743 

## Changes

@dberenbaum, I felt that both approaches need to be implemented together. Inferring the format is nice, but only works in _some_ situations and not others. So for a situation where the format could not be inferred, I added an additional check that will fail early and won't attempt saving the image.

My Python must be _not optimal_. The changes are split into two commits, feature-wise. 
- I've also added unit tests for the behavior.
- Behavior change: in `could_log` I suggest we take `name` and `val`, not just val. This might be a bad idea if it's used elsewhere (not in this repository, I checked). It's not in public API, though. 

I'm not strongly attached to the `could_log` idea. In the end of the day, it's only saving us a bit of time, and clarifies the error, but it's not strictly required.

## TODO
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst)
  guide.

- [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
