### PR TITLE
log_params: fix invalid type msg

### DIFF
--- a/src/dvclive/error.py
+++ b/src/dvclive/error.py
@@ -29,9 +29,8 @@ class InvalidPlotTypeError(DvcLiveError):
 
 
 class InvalidParameterTypeError(DvcLiveError):
-    def __init__(self, val: Any):
-        self.val = val
-        super().__init__(f"Parameter type {type(val)} is not supported.")
+    def __init__(self, msg: Any):
+        super().__init__(msg)
 
 
 class InvalidReportModeError(DvcLiveError):

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -454,7 +454,7 @@ class Live:
         try:
             dump_yaml(self._params, self.params_file)
         except RepresenterError as exc:
-            raise InvalidParameterTypeError(exc.args) from exc
+            raise InvalidParameterTypeError(exc.args[0]) from exc
 
     def log_params(self, params: Dict[str, ParamLike]):
         """Saves the given set of parameters (dict) to yaml"""

--- a/tests/test_log_param.py
+++ b/tests/test_log_param.py
@@ -84,5 +84,6 @@ def test_log_param_custom_obj(tmp_dir):
 
     param_value = Dummy()
 
-    with pytest.raises(InvalidParameterTypeError):
+    with pytest.raises(InvalidParameterTypeError) as excinfo:
         dvclive.log_param("param_complex", param_value)
+    assert "Dummy" in excinfo.value.args[0]


### PR DESCRIPTION
Before this PR, when logging an invalid parameter type, you would always get a generic error message that doesn't reflect the actual type passed:

```python
>>> Live().log_param("p", pd.DataFrame())
...
dvclive.error.InvalidParameterTypeError: Parameter type <class 'tuple'> is not supported.
```

With this PR, you get info about the actual invalid type passed:


```python
>>> Live().log_param("p", pd.DataFrame())
...
dvclive.error.InvalidParameterTypeError: cannot represent an object: Empty DataFrame
```

This happens because `log_params` dumps a dict to yaml and the error comes from failing to write to yaml. Unfortunately, I don't see an easy way to parse the error output to get more control over the message.