### PR TITLE
Add support for DataFrames and Numpy Arrays for log_plot()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 image = ["numpy", "pillow"]
 sklearn = ["scikit-learn"]
-plots = ["scikit-learn"]
+plots = ["scikit-learn", "pandas", "numpy"]
 markdown = ["matplotlib"]
 tests = [
     "pytest>=7.2.0,<8.0",

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -2,7 +2,9 @@ import glob
 import json
 import logging
 import math
+import numpy as np
 import os
+import pandas as pd
 import shutil
 import tempfile
 from pathlib import Path
@@ -35,6 +37,7 @@ from .utils import (
     StrPath,
     catch_and_warn,
     clean_and_copy_into,
+    convert_datapoints_to_list_of_dicts,
     env2bool,
     inside_notebook,
     matplotlib_installed,
@@ -391,14 +394,19 @@ class Live:
     def log_plot(
         self,
         name: str,
-        datapoints: List[Dict],
+        datapoints: pd.DataFrame | np.ndarray | List[Dict],
         x: str,
         y: str,
         template: Optional[str] = None,
         title: Optional[str] = None,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
+        columns: Optional[List[str]] = None,
     ):
+        
+        # Convert the given datapoints to List[Dict]
+        datapoints = convert_datapoints_to_list_of_dicts(datapoints=datapoints, columns=columns)
+
         if not CustomPlot.could_log(datapoints):
             raise InvalidDataTypeError(name, type(datapoints))
 

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -403,9 +403,10 @@ class Live:
         y_label: Optional[str] = None,
         columns: Optional[List[str]] = None,
     ):
-        
         # Convert the given datapoints to List[Dict]
-        datapoints = convert_datapoints_to_list_of_dicts(datapoints=datapoints, columns=columns)
+        datapoints = convert_datapoints_to_list_of_dicts(
+            datapoints=datapoints, columns=columns
+        )
 
         if not CustomPlot.could_log(datapoints):
             raise InvalidDataTypeError(name, type(datapoints))

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
 import glob
 import json
 import logging
 import math
-import numpy as np
 import os
-import pandas as pd
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
 
 from dvc.exceptions import DvcException
 from funcy import set_in
@@ -401,12 +404,9 @@ class Live:
         title: Optional[str] = None,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
-        columns: Optional[List[str]] = None,
     ):
         # Convert the given datapoints to List[Dict]
-        datapoints = convert_datapoints_to_list_of_dicts(
-            datapoints=datapoints, columns=columns
-        )
+        datapoints = convert_datapoints_to_list_of_dicts(datapoints=datapoints)
 
         if not CustomPlot.could_log(datapoints):
             raise InvalidDataTypeError(name, type(datapoints))

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -1,12 +1,14 @@
 import csv
 import json
+import numpy as np
 import os
+import pandas as pd
 import re
 import shutil
-import webbrowser
 from pathlib import Path
 from platform import uname
-from typing import Union
+from typing import Union, List, Dict, Optional
+import webbrowser
 
 StrPath = Union[str, Path]
 
@@ -194,3 +196,29 @@ def read_history(live, metric):
 def read_latest(live, metric_name):
     _, latest = parse_metrics(live)
     return latest["step"], latest[metric_name]
+
+
+def convert_datapoints_to_list_of_dicts(
+        datapoints: pd.DataFrame | np.ndarray | List[Dict], 
+        columns: Optional[List[str]] = None
+        ) -> List[Dict]:
+    """
+    Convert the given datapoints to a list of dictionaries.
+
+    Args:
+        datapoints: The input datapoints to be converted.
+        columns: The column columns for the datapoints. Applied only for np.ndarray inputs.
+
+    Returns:
+        A list of dictionaries representing the datapoints.
+
+    Raises:
+        None
+    """
+    if isinstance(datapoints, pd.DataFrame):
+        return datapoints.to_dict(orient='records')
+    elif isinstance(datapoints, np.ndarray):
+        return pd.DataFrame(datapoints, columns=columns).to_dict(orient='records')
+    else:
+        return datapoints
+

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
 import csv
 import json
-import numpy as np
 import os
-import pandas as pd
 import re
 import shutil
 from pathlib import Path
 from platform import uname
-from typing import Union, List, Dict, Optional
+from typing import Union, List, Dict, Optional, TYPE_CHECKING
 import webbrowser
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
 
 StrPath = Union[str, Path]
 
@@ -199,25 +202,32 @@ def read_latest(live, metric_name):
 
 
 def convert_datapoints_to_list_of_dicts(
-    datapoints: pd.DataFrame | np.ndarray | List[Dict],
-    columns: Optional[List[str]] = None,
-) -> List[Dict]:
+        datapoints:  List[Dict] | pd.DataFrame | np.ndarray,
+        ) -> List[Dict]:
     """
     Convert the given datapoints to a list of dictionaries.
 
     Args:
         datapoints: The input datapoints to be converted.
-        columns: The column columns for the datapoints. Applied only for np.ndarray inputs.
 
     Returns:
         A list of dictionaries representing the datapoints.
 
     Raises:
-        None
+        ValueError: If the `datapoints` argument is not of type pd.DataFrame, np.ndarray, or List[Dict].
     """
-    if isinstance(datapoints, pd.DataFrame):
-        return datapoints.to_dict(orient="records")
-    elif isinstance(datapoints, np.ndarray):
-        return pd.DataFrame(datapoints, columns=columns).to_dict(orient="records")
-    else:
+    if isinstance(datapoints, list):
         return datapoints
+
+    import pandas as pd
+    if isinstance(datapoints, pd.DataFrame):
+        return datapoints.to_dict(orient='records')
+
+    import numpy as np
+    if isinstance(datapoints, np.ndarray):
+        return pd.DataFrame(datapoints).to_dict(orient='records')
+    else:
+        raise ValueError("""
+            Unexpected format for `datapoints`. \
+            Supported formats: pd.DataFrame, np.ndarray, or List[Dict].
+            """)

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -7,11 +7,16 @@ import shutil
 from pathlib import Path
 from platform import uname
 from typing import Union, List, Dict, TYPE_CHECKING
+from typing import Union, List, Dict, TYPE_CHECKING
 import webbrowser
 
 if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
+
+from .error import (
+    InvalidDataTypeError,
+)
 
 StrPath = Union[str, Path]
 
@@ -204,6 +209,8 @@ def read_latest(live, metric_name):
 def convert_datapoints_to_list_of_dicts(
     datapoints: List[Dict] | pd.DataFrame | np.ndarray,
 ) -> List[Dict]:
+    datapoints: List[Dict] | pd.DataFrame | np.ndarray,
+) -> List[Dict]:
     """
     Convert the given datapoints to a list of dictionaries.
 
@@ -214,24 +221,22 @@ def convert_datapoints_to_list_of_dicts(
         A list of dictionaries representing the datapoints.
 
     Raises:
-        ValueError: If the `datapoints` argument is not of type pd.DataFrame, np.ndarray, or List[Dict].
+        TypeError: `datapoints` must be pd.DataFrame, np.ndarray, or List[Dict]
     """
     if isinstance(datapoints, list):
         return datapoints
 
     import pandas as pd
 
+
     if isinstance(datapoints, pd.DataFrame):
+        return datapoints.to_dict(orient="records")
         return datapoints.to_dict(orient="records")
 
     import numpy as np
 
+
     if isinstance(datapoints, np.ndarray):
         return pd.DataFrame(datapoints).to_dict(orient="records")
-    else:
-        raise ValueError(
-            """
-            Unexpected format for `datapoints`. \
-            Supported formats: pd.DataFrame, np.ndarray, or List[Dict].
-            """
-        )
+
+    return datapoints

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -225,7 +225,6 @@ def convert_datapoints_to_list_of_dicts(
 
     if isinstance_without_import(datapoints, "pandas.core.frame", "DataFrame"):
         return datapoints.to_dict(orient="records")
-        return datapoints.to_dict(orient="records")
 
     if isinstance_without_import(datapoints, "numpy", "ndarray"):
         # This is a structured array

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -6,7 +6,7 @@ import re
 import shutil
 from pathlib import Path
 from platform import uname
-from typing import Union, List, Dict, Optional, TYPE_CHECKING
+from typing import Union, List, Dict, TYPE_CHECKING
 import webbrowser
 
 if TYPE_CHECKING:
@@ -202,8 +202,8 @@ def read_latest(live, metric_name):
 
 
 def convert_datapoints_to_list_of_dicts(
-        datapoints:  List[Dict] | pd.DataFrame | np.ndarray,
-        ) -> List[Dict]:
+    datapoints: List[Dict] | pd.DataFrame | np.ndarray,
+) -> List[Dict]:
     """
     Convert the given datapoints to a list of dictionaries.
 
@@ -220,14 +220,18 @@ def convert_datapoints_to_list_of_dicts(
         return datapoints
 
     import pandas as pd
+
     if isinstance(datapoints, pd.DataFrame):
-        return datapoints.to_dict(orient='records')
+        return datapoints.to_dict(orient="records")
 
     import numpy as np
+
     if isinstance(datapoints, np.ndarray):
-        return pd.DataFrame(datapoints).to_dict(orient='records')
+        return pd.DataFrame(datapoints).to_dict(orient="records")
     else:
-        raise ValueError("""
+        raise ValueError(
+            """
             Unexpected format for `datapoints`. \
             Supported formats: pd.DataFrame, np.ndarray, or List[Dict].
-            """)
+            """
+        )

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -9,6 +9,8 @@ from platform import uname
 from typing import Union, List, Dict, TYPE_CHECKING
 import webbrowser
 
+from .error import InvalidDataTypeError
+
 if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
@@ -23,9 +25,7 @@ else:
     except ImportError:
         np = None
 
-from .error import (
-    InvalidDataTypeError,
-)
+
 
 StrPath = Union[str, Path]
 

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -7,7 +7,6 @@ import shutil
 from pathlib import Path
 from platform import uname
 from typing import Union, List, Dict, TYPE_CHECKING
-from typing import Union, List, Dict, TYPE_CHECKING
 import webbrowser
 
 if TYPE_CHECKING:
@@ -209,8 +208,6 @@ def read_latest(live, metric_name):
 def convert_datapoints_to_list_of_dicts(
     datapoints: List[Dict] | pd.DataFrame | np.ndarray,
 ) -> List[Dict]:
-    datapoints: List[Dict] | pd.DataFrame | np.ndarray,
-) -> List[Dict]:
     """
     Convert the given datapoints to a list of dictionaries.
 
@@ -226,17 +223,17 @@ def convert_datapoints_to_list_of_dicts(
     if isinstance(datapoints, list):
         return datapoints
 
-    import pandas as pd
-
-
-    if isinstance(datapoints, pd.DataFrame):
+    if isinstance_without_import(datapoints, "pandas.core.frame", "DataFrame"):
         return datapoints.to_dict(orient="records")
         return datapoints.to_dict(orient="records")
 
-    import numpy as np
+    if isinstance_without_import(datapoints, "numpy", "ndarray"):
+        # This is a structured array
+        if datapoints.dtype.names is not None:
+            return [dict(zip(datapoints.dtype.names, row)) for row in datapoints]
 
+        # This is a regular array
+        return [dict(enumerate(row)) for row in datapoints]
 
-    if isinstance(datapoints, np.ndarray):
-        return pd.DataFrame(datapoints).to_dict(orient="records")
-
-    return datapoints
+    # Raise an error if the input is not a supported type
+    raise InvalidDataTypeError("datapoints", type(datapoints))

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -12,6 +12,16 @@ import webbrowser
 if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
+else:
+    try:
+        import pandas as pd
+    except ImportError:
+        pd = None
+
+    try:
+        import numpy as np
+    except ImportError:
+        np = None
 
 from .error import (
     InvalidDataTypeError,
@@ -223,10 +233,10 @@ def convert_datapoints_to_list_of_dicts(
     if isinstance(datapoints, list):
         return datapoints
 
-    if isinstance_without_import(datapoints, "pandas.core.frame", "DataFrame"):
+    if pd and isinstance(datapoints, pd.DataFrame):
         return datapoints.to_dict(orient="records")
 
-    if isinstance_without_import(datapoints, "numpy", "ndarray"):
+    if np and isinstance(datapoints, np.ndarray):
         # This is a structured array
         if datapoints.dtype.names is not None:
             return [dict(zip(datapoints.dtype.names, row)) for row in datapoints]

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -26,7 +26,6 @@ else:
         np = None
 
 
-
 StrPath = Union[str, Path]
 
 

--- a/src/dvclive/utils.py
+++ b/src/dvclive/utils.py
@@ -199,9 +199,9 @@ def read_latest(live, metric_name):
 
 
 def convert_datapoints_to_list_of_dicts(
-        datapoints: pd.DataFrame | np.ndarray | List[Dict], 
-        columns: Optional[List[str]] = None
-        ) -> List[Dict]:
+    datapoints: pd.DataFrame | np.ndarray | List[Dict],
+    columns: Optional[List[str]] = None,
+) -> List[Dict]:
     """
     Convert the given datapoints to a list of dictionaries.
 
@@ -216,9 +216,8 @@ def convert_datapoints_to_list_of_dicts(
         None
     """
     if isinstance(datapoints, pd.DataFrame):
-        return datapoints.to_dict(orient='records')
+        return datapoints.to_dict(orient="records")
     elif isinstance(datapoints, np.ndarray):
-        return pd.DataFrame(datapoints, columns=columns).to_dict(orient='records')
+        return pd.DataFrame(datapoints, columns=columns).to_dict(orient="records")
     else:
         return datapoints
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
+import numpy as np
+import pandas as pd
 import pytest
+from typing import List, Dict, Optional
 
-from dvclive.utils import standardize_metric_name
+from dvclive.utils import standardize_metric_name, convert_datapoints_to_list_of_dicts
 
 
 @pytest.mark.parametrize(
@@ -15,3 +18,26 @@ from dvclive.utils import standardize_metric_name
 )
 def test_standardize_metric_name(framework, logged, standardized):
     assert standardize_metric_name(logged, framework) == standardized
+
+
+
+class TestConvertDatapointsToListOfDicts:
+    def test_dataframe(self):
+        df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
+        expected_output = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        assert convert_datapoints_to_list_of_dicts(df) == expected_output
+
+    def test_ndarray_with_columns(self):
+        arr = np.array([[1, 3], [2, 4]])
+        columns = ['A', 'B']
+        expected_output = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        assert convert_datapoints_to_list_of_dicts(arr, columns) == expected_output
+
+    def test_ndarray_without_columns(self):
+        arr = np.array([[1, 3], [2, 4]])
+        expected_output = [{0: 1, 1: 3}, {0: 2, 1: 4}]
+        assert convert_datapoints_to_list_of_dicts(arr) == expected_output
+
+    def test_list_of_dicts(self):
+        list_of_dicts = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        assert convert_datapoints_to_list_of_dicts(list_of_dicts) == list_of_dicts

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,17 +25,23 @@ class TestConvertDatapointsToListOfDicts:
         expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(df) == expected_output
 
-    def test_ndarray_with_columns(self):
-        arr = np.array([[1, 3], [2, 4]])
-        columns = ["A", "B"]
-        expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
-        assert convert_datapoints_to_list_of_dicts(arr, columns) == expected_output
-
-    def test_ndarray_without_columns(self):
+    def test_ndarray(self):
         arr = np.array([[1, 3], [2, 4]])
         expected_output = [{0: 1, 1: 3}, {0: 2, 1: 4}]
         assert convert_datapoints_to_list_of_dicts(arr) == expected_output
 
+    def test_structured_array(self):
+        dtype = [('A', 'i4'), ('B', 'i4')]
+        structured_array = np.array([(1, 3), (2, 4)], dtype=dtype)
+        expected_output = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        assert convert_datapoints_to_list_of_dicts(structured_array) == expected_output
+
     def test_list_of_dicts(self):
         list_of_dicts = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(list_of_dicts) == list_of_dicts
+
+    def test_unsupported_format(self):
+        with pytest.raises(ValueError) as exc_info:
+            convert_datapoints_to_list_of_dicts("unsupported data format")
+
+        assert "Unexpected format for `datapoints`" in str(exc_info.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,9 +39,3 @@ class TestConvertDatapointsToListOfDicts:
     def test_list_of_dicts(self):
         list_of_dicts = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(list_of_dicts) == list_of_dicts
-
-    def test_unsupported_format(self):
-        with pytest.raises(ValueError) as exc_info:
-            convert_datapoints_to_list_of_dicts("unsupported data format")
-
-        assert "Unexpected format for `datapoints`" in str(exc_info.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from dvclive.utils import standardize_metric_name, convert_datapoints_to_list_of_dicts
+from dvclive.error import InvalidDataTypeError
 
 
 @pytest.mark.parametrize(
@@ -39,3 +40,9 @@ class TestConvertDatapointsToListOfDicts:
     def test_list_of_dicts(self):
         list_of_dicts = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(list_of_dicts) == list_of_dicts
+
+    def test_unsupported_format(self):
+        with pytest.raises(InvalidDataTypeError) as exc_info:
+            convert_datapoints_to_list_of_dicts("unsupported data format")
+
+        assert "not supported type" in str(exc_info.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,9 +31,9 @@ class TestConvertDatapointsToListOfDicts:
         assert convert_datapoints_to_list_of_dicts(arr) == expected_output
 
     def test_structured_array(self):
-        dtype = [('A', 'i4'), ('B', 'i4')]
+        dtype = [("A", "i4"), ("B", "i4")]
         structured_array = np.array([(1, 3), (2, 4)], dtype=dtype)
-        expected_output = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(structured_array) == expected_output
 
     def test_list_of_dicts(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,29 +20,28 @@ def test_standardize_metric_name(framework, logged, standardized):
     assert standardize_metric_name(logged, framework) == standardized
 
 
-class TestConvertDatapointsToListOfDicts:
-    def test_dataframe(self):
-        df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
-        expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
-        assert convert_datapoints_to_list_of_dicts(df) == expected_output
+# Tests for convert_datapoints_to_list_of_dicts()
+@pytest.mark.parametrize(
+    ("input_data", "expected_output"),
+    [
+        (
+            pd.DataFrame({"A": [1, 2], "B": [3, 4]}),
+            [{"A": 1, "B": 3}, {"A": 2, "B": 4}],
+        ),
+        (np.array([[1, 3], [2, 4]]), [{0: 1, 1: 3}, {0: 2, 1: 4}]),
+        (
+            np.array([(1, 3), (2, 4)], dtype=[("A", "i4"), ("B", "i4")]),
+            [{"A": 1, "B": 3}, {"A": 2, "B": 4}],
+        ),
+        ([{"A": 1, "B": 3}, {"A": 2, "B": 4}], [{"A": 1, "B": 3}, {"A": 2, "B": 4}]),
+    ],
+)
+def test_convert_datapoints_to_list_of_dicts(input_data, expected_output):
+    assert convert_datapoints_to_list_of_dicts(input_data) == expected_output
 
-    def test_ndarray(self):
-        arr = np.array([[1, 3], [2, 4]])
-        expected_output = [{0: 1, 1: 3}, {0: 2, 1: 4}]
-        assert convert_datapoints_to_list_of_dicts(arr) == expected_output
 
-    def test_structured_array(self):
-        dtype = [("A", "i4"), ("B", "i4")]
-        structured_array = np.array([(1, 3), (2, 4)], dtype=dtype)
-        expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
-        assert convert_datapoints_to_list_of_dicts(structured_array) == expected_output
+def test_unsupported_format():
+    with pytest.raises(InvalidDataTypeError) as exc_info:
+        convert_datapoints_to_list_of_dicts("unsupported data format")
 
-    def test_list_of_dicts(self):
-        list_of_dicts = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
-        assert convert_datapoints_to_list_of_dicts(list_of_dicts) == list_of_dicts
-
-    def test_unsupported_format(self):
-        with pytest.raises(InvalidDataTypeError) as exc_info:
-            convert_datapoints_to_list_of_dicts("unsupported data format")
-
-        assert "not supported type" in str(exc_info.value)
+    assert "not supported type" in str(exc_info.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-from typing import List, Dict, Optional
 
 from dvclive.utils import standardize_metric_name, convert_datapoints_to_list_of_dicts
 
@@ -20,17 +19,16 @@ def test_standardize_metric_name(framework, logged, standardized):
     assert standardize_metric_name(logged, framework) == standardized
 
 
-
 class TestConvertDatapointsToListOfDicts:
     def test_dataframe(self):
-        df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
-        expected_output = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+        expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(df) == expected_output
 
     def test_ndarray_with_columns(self):
         arr = np.array([[1, 3], [2, 4]])
-        columns = ['A', 'B']
-        expected_output = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        columns = ["A", "B"]
+        expected_output = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(arr, columns) == expected_output
 
     def test_ndarray_without_columns(self):
@@ -39,5 +37,5 @@ class TestConvertDatapointsToListOfDicts:
         assert convert_datapoints_to_list_of_dicts(arr) == expected_output
 
     def test_list_of_dicts(self):
-        list_of_dicts = [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+        list_of_dicts = [{"A": 1, "B": 3}, {"A": 2, "B": 4}]
         assert convert_datapoints_to_list_of_dicts(list_of_dicts) == list_of_dicts


### PR DESCRIPTION
This PR is a part of this issue: https://github.com/iterative/dvclive/issues/750 

Changes: 
- add support for Add support for DataFrames and Numpy Arrays in `log_plot()` 
- implemented a new function for convert datapoints to List[Dict] `dvclive/utils.py/convert_datapoints_to_list_of_dicts` 
- added new Python dependencies: `pandas` and `numpy`
- added a new argument to the `log_plot()`: `columns: Optional[List[str]] = None,` - optional list of column names for data in Numpy Array format

JN to test new feature: [log_plots.ipynb](https://drive.google.com/file/d/1tDoigZrpo_YzPiS-fXsrDHSJuSmgM-uT/view?usp=sharing)

### TODO
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst)
  guide.
- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR: https://github.com/iterative/dvc.org/pull/5055 
