### PR TITLE
preserve summary metrics on resume

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -121,6 +121,7 @@ class Live:
 
     def _init_resume(self):
         self._read_params()
+        self.summary = self.read_latest()
         self._step = self.read_step()
         if self._step != 0:
             logger.info(f"Resuming from step {self._step}")
@@ -607,14 +608,14 @@ class Live:
         cleanup_dvclive_step_completed()
 
     def read_step(self):
-        if Path(self.metrics_file).exists():
-            latest = self.read_latest()
-            return latest.get("step", 0)
-        return 0
+        latest = self.read_latest()
+        return latest.get("step", 0)
 
     def read_latest(self):
-        with open(self.metrics_file, encoding="utf-8") as fobj:
-            return json.load(fobj)
+        if Path(self.metrics_file).exists():
+            with open(self.metrics_file, encoding="utf-8") as fobj:
+                return json.load(fobj)
+        return {}
 
     def __enter__(self):
         self._inside_with = True

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -15,6 +15,8 @@ def test_resume(tmp_dir, resume, steps, metrics):
     for metric in [0.9, 0.8]:
         dvclive.log_metric("metric", metric)
         dvclive.next_step()
+    dvclive.log_metric("summary", 1)
+    dvclive.end()
 
     assert read_history(dvclive, "metric") == ([0, 1], [0.9, 0.8])
     assert read_latest(dvclive, "metric") == (1, 0.8)
@@ -24,9 +26,14 @@ def test_resume(tmp_dir, resume, steps, metrics):
     for new_metric in [0.7, 0.6]:
         dvclive.log_metric("metric", new_metric)
         dvclive.next_step()
+    dvclive.end()
 
     assert read_history(dvclive, "metric") == (steps, metrics)
     assert read_latest(dvclive, "metric") == (steps[-1], metrics[-1])
+    if resume:
+        assert dvclive.read_latest()["summary"] == 1
+    else:
+        assert "summary" not in dvclive.read_latest()
 
 
 def test_resume_on_first_init(tmp_dir):


### PR DESCRIPTION
Dvclive was not preserving summary metrics when `resume=True`.