### PR TITLE
Fix `TypeError` by explictly calling shadowed `builtins.type`

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import builtins
 import glob
 import json
 import logging
@@ -491,7 +492,7 @@ class Live:
     ):
         """Tracks a local file or directory with DVC"""
         if not isinstance(path, (str, Path)):
-            raise InvalidDataTypeError(path, type(path))
+            raise InvalidDataTypeError(path, builtins.type(path))
 
         if self._dvc_repo is not None:
             from gto.constants import assert_name_is_valid

--- a/tests/test_log_artifact.py
+++ b/tests/test_log_artifact.py
@@ -5,6 +5,7 @@ import pytest
 from dvc.exceptions import DvcException
 
 from dvclive import Live
+from dvclive.error import InvalidDataTypeError
 from dvclive.serialize import load_yaml
 
 dvcyaml = """
@@ -295,3 +296,11 @@ def test_log_artifact_no_repo(tmp_dir, mocker):
     logger.warning.assert_called_with(
         "A DVC repo is required to log artifacts. Skipping `log_artifact(data)`."
     )
+
+
+@pytest.mark.parametrize("invalid_path", [None, 1.0, True, [], {}], ids=type)
+def test_log_artifact_invalid_path_type(invalid_path, tmp_dir):
+    live = Live(save_dvc_exp=False)
+    expected_error_msg = f"not supported type {type(invalid_path)}"
+    with pytest.raises(InvalidDataTypeError, match=expected_error_msg):
+        live.log_artifact(path=invalid_path)


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst)
  guide.

- [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Closes #761 by explicitly calling `builtins.type` instead of the `type` argument that's shadowing it.