### PR TITLE
Add docstrings to public functions

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -516,8 +516,6 @@ class Live:
         included in the plots section written by `Live.make_dvcyaml()`. The plot can be
         rendered with `DVC CLI`, `VSCode Extension` or `DVC Studio`.
 
-
-
         Args:
             name (StrPath): name of the output file.
             datapoints (pd.DataFrame | np.ndarray | List[Dict]): Pandas DataFrame, Numpy

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -456,7 +456,7 @@ class Live:
     def log_image(
         self,
         name: str,
-        val: Union[np.ndarray, matplotlib.figure.Figure, PIL.Image, StrPath]
+        val: Union[np.ndarray, matplotlib.figure.Figure, PIL.Image, StrPath],
     ):
         """
         Saves the given image `val` to the output file `name`.


### PR DESCRIPTION
This PR fix this issue: https://github.com/iterative/dvclive/issues/755

I was inspired by the dvc.org documentation for most arguments and descriptions. Let me know if you were hoping for something more technical. 

I'm still struggling to find a nice description for `cache`, `post_to_studio` and `save_dvc_exp`. If you could enlighten me so I can finish this MR, that would be great. 

I notice some missing type hints in the methods. I would love to correct those, but I'll do it on another PR.

- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.
- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.