### PR TITLE
DRAFT: add log_bounding_boxes to Live

### DIFF
--- a/src/dvclive/error.py
+++ b/src/dvclive/error.py
@@ -39,3 +39,11 @@ class InvalidReportModeError(DvcLiveError):
             f"`report` can only be `None`, `auto`, `html`, `notebook` or `md`. "
             f"Got {val} instead."
         )
+
+
+class InvalidSameSizeError(DvcLiveError):
+    def __init__(self, name, x, y):
+        self.name = name
+        self.x = x
+        self.y = y
+        super().__init__(f"Data '{name}': '{x}' and '{y}' must have the same length")

--- a/src/dvclive/plots/__init__.py
+++ b/src/dvclive/plots/__init__.py
@@ -1,5 +1,6 @@
 from .custom import CustomPlot
 from .image import Image
+from .bounding_boxes import BoundingBoxes  # noqa: F401
 from .metric import Metric
 from .sklearn import Calibration, ConfusionMatrix, Det, PrecisionRecall, Roc
 from .utils import NumpyEncoder  # noqa: F401

--- a/src/dvclive/plots/bounding_boxes.py
+++ b/src/dvclive/plots/bounding_boxes.py
@@ -1,0 +1,109 @@
+from typing import List, Literal, Union
+import math
+
+
+import numpy as np
+from pathlib import Path
+
+from dvclive.plots.utils import NumpyEncoder
+from dvclive.serialize import dump_json
+from dvclive.error import InvalidSameSizeError, InvalidDataTypeError
+
+from .base import Data
+
+BboxFormatKind = Literal["tlbr", "tlhw", "xywh"]
+
+
+class BoundingBoxes(Data):
+    suffixes = (".json",)
+    subfolder = "images"
+
+    @property
+    def output_path(self) -> Path:
+        _path = self.output_folder / self.name
+        _path.parent.mkdir(exist_ok=True, parents=True)
+        return _path
+
+    @staticmethod
+    def could_log(
+        name: str,
+        bounding_boxes: Union[List[List[int]], np.ndarray],
+        labels: List[str],
+        scores: List[float],
+        format: BboxFormatKind,  # noqa: A002
+    ) -> bool:
+        if not any(name.endswith(suffix) for suffix in BoundingBoxes.suffixes):
+            raise InvalidDataTypeError(name, type(name))
+
+        if len(bounding_boxes) != len(labels):
+            raise InvalidSameSizeError(name, "bounding_boxes", "labels")
+
+        if len(bounding_boxes) != len(scores):
+            raise InvalidSameSizeError(name, "bounding_boxes", "scores")
+
+        if format not in ["tlbr", "tlhw", "xywh"]:
+            raise InvalidDataTypeError(name, type(format))
+
+        if not all(isinstance(score, float) for score in scores):
+            raise InvalidDataTypeError(name, type(scores))
+
+        if not all(
+            isinstance(x, (int, np.int_)) for bbox in bounding_boxes for x in bbox
+        ):
+            raise InvalidDataTypeError(name, type(bounding_boxes))
+
+        if not all(isinstance(label, str) for label in labels):
+            raise InvalidDataTypeError(name, type(labels))
+        return
+
+    def dump(
+        self,
+        bboxes: Union[List[List[int]], np.ndarray],
+        labels: List[str],
+        scores: List[float],
+        format: BboxFormatKind,  # noqa: A002
+    ) -> None:
+        bboxes = self.convert_to_tlbr(bboxes, format)
+        json_content = {
+            "boxes": [
+                {
+                    "label": label,
+                    "box": {
+                        "top": tlbr[0],
+                        "left": tlbr[1],
+                        "bottom": tlbr[2],
+                        "right": tlbr[3],
+                    },
+                    "score": score,
+                }
+                for tlbr, label, score in zip(bboxes, labels, scores)
+            ]
+        }
+
+        dump_json(json_content, self.output_path, cls=NumpyEncoder)
+
+    @staticmethod
+    def convert_to_tlbr(
+        bboxes: Union[List[List[int]], "np.ndarray"],
+        format: BboxFormatKind,  # noqa: A002
+    ) -> List[List[int]]:
+        """
+        Converts bounding boxes from different formats to the top, left, bottom, right
+        format.
+        """
+        if format == "tlhw":
+            return [
+                [box[0], box[1], box[0] + box[2], box[1] + box[3]] for box in bboxes
+            ]
+
+        if format == "xywh":
+            return [
+                [
+                    box[0] - math.ceil(box[2] / 2),
+                    box[1] - math.ceil(box[3] / 2),
+                    box[0] + math.floor(box[2] / 2),
+                    box[1] + math.floor(box[3] / 2),
+                ]
+                for box in bboxes
+            ]
+        return bboxes

--- a/tests/plots/test_bounding_boxes.py
+++ b/tests/plots/test_bounding_boxes.py
@@ -1,0 +1,257 @@
+import numpy as np
+import pytest
+
+from dvclive import Live
+from dvclive.plots import BoundingBoxes
+from dvclive.error import InvalidDataTypeError, InvalidSameSizeError
+
+
+@pytest.mark.parametrize(
+    ("name", "bounding_boxes", "labels", "scores"),
+    [
+        ("image.json", [], [], []),
+        ("image.json", [[10, 20, 30, 40]], ["A"], [0.7]),
+        ("image.json", [[0, 0, 10, 10], [10, 150, 300, 500]], ["B", "C"], [0.5, 0.8]),
+        (
+            "image.json",
+            np.array([[0, 0, 10, 10], [10, 150, 300, 500]]),
+            ["B", "C"],
+            [0.5, 0.8],
+        ),
+        (
+            "image.json",
+            [[0, 0, 10, 10], [10, 150, 300, 500]],
+            np.array(["B", "C"]),
+            [0.5, 0.8],
+        ),
+        (
+            "image.json",
+            [[0, 0, 10, 10], [10, 150, 300, 500]],
+            ["B", "C"],
+            np.array([0.5, 0.8]),
+        ),
+    ],
+)
+def test_save_json_file(name, bounding_boxes, labels, scores, tmp_dir):
+    live = Live()
+    live.log_bounding_boxes(name, bounding_boxes, labels, scores, format="tlbr")
+    assert (tmp_dir / live.plots_dir / BoundingBoxes.subfolder / name).exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "bounding_boxes", "labels", "scores"),
+    [
+        ("image.png", [], [], []),
+        ("image.jpg", [[10, 20, 30, 40]], ["A"], [0.7]),
+        ("image.yaml", [[0, 0, 10, 10], [10, 150, 300, 500]], ["B", "C"], [0.5, 0.8]),
+    ],
+)
+def test_invalid_extension(name, bounding_boxes, labels, scores, tmp_dir):
+    live = Live()
+    with pytest.raises(InvalidDataTypeError):
+        live.log_bounding_boxes(
+            name,
+            bounding_boxes,
+            labels,
+            scores,
+            format="tlbr",
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "bounding_boxes", "labels", "scores"),
+    [
+        ("image.json", [[10, 20, 30, 40], [10, 20, 30, 40]], ["A"], [0.1, 0.2]),
+        ("image.json", [[10, 20, 30, 40]], ["A", "B"], [0.7]),
+    ],
+)
+def test_invalid_labels_size(name, bounding_boxes, labels, scores, tmp_dir):
+    live = Live()
+    with pytest.raises(
+        InvalidSameSizeError,
+        match="Data 'image.json': "
+        "'bounding_boxes' and 'labels' must have the same length",
+    ):
+        live.log_bounding_boxes(
+            name,
+            bounding_boxes,
+            labels,
+            scores,
+            format="tlbr",
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "bounding_boxes", "labels", "scores"),
+    [
+        ("image.json", [[10, 20, 30, 40], [10, 20, 30, 40]], ["A", "B"], [0.1]),
+        ("image.json", [[10, 20, 30, 40]], ["A"], [0.7, 0.4]),
+    ],
+)
+def test_invalid_scores_size(name, bounding_boxes, labels, scores, tmp_dir):
+    live = Live()
+    with pytest.raises(
+        InvalidSameSizeError,
+        match="Data 'image.json': "
+        "'bounding_boxes' and 'scores' must have the same length",
+    ):
+        live.log_bounding_boxes(
+            name,
+            bounding_boxes,
+            labels,
+            scores,
+            format="tlbr",
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "bounding_boxes", "labels", "scores"),
+    [
+        ("image.json", [[10, 20, 30.5, 40], [10, 20, 30, 40]], ["A", "B"], [0.1, 0.2]),
+        ("image.json", [[10, 20, 30, 40]], [0], [0.7]),
+        ("image.json", [[10, 20, 30, 40]], [0.1], [0.7]),
+        ("image.json", [[10, 20, 30, 40]], [["A", "B"]], [0.7]),
+        ("image.json", [[10, 20, 30, 40]], ["A"], [1]),
+        ("image.json", [[10, 20, 30, 40]], ["A"], [0]),
+        ("image.json", [[10, 20, 30, 40]], ["A"], ["score"]),
+    ],
+)
+def test_invalid_inputs_format(name, bounding_boxes, labels, scores, tmp_dir):
+    live = Live()
+    with pytest.raises(InvalidDataTypeError):
+        live.log_bounding_boxes(
+            name,
+            bounding_boxes,
+            labels,
+            scores,
+            format="tlbr",
+        )
+
+
+def test_path(tmp_dir):
+    import json
+
+    json_path = tmp_dir / "image.json"
+    with open(json_path, "w") as json_file:
+        json.dump({}, json_file)
+
+    live = Live()
+    live.log_bounding_boxes(
+        "image.json",
+        [[0, 0, 10, 10]],
+        ["cat"],
+        [0.2],
+        format="tlbr",
+    )
+    live.end()
+
+    file_path = tmp_dir / live.plots_dir / "images" / "image.json"
+    assert file_path.exists()
+
+    with open(file_path) as json_file:
+        file_content = json.load(json_file)
+
+    assert file_content == {
+        "boxes": [
+            {
+                "box": {"top": 0, "left": 0, "bottom": 10, "right": 10},
+                "label": "cat",
+                "score": 0.2,
+            }
+        ]
+    }
+
+
+def test_override_on_step(tmp_dir):
+    import json
+
+    live = Live()
+
+    live.log_bounding_boxes(
+        "image.json",
+        [[0, 0, 10, 10]],
+        ["cat"],
+        [0.2],
+        format="tlbr",
+    )
+
+    live.next_step()
+
+    bboxes_step_2 = [[10, 20, 30, 40]]
+    labels_step_2 = ["dog"]
+    scores_step_2 = [0.5]
+    live.log_bounding_boxes(
+        "image.json",
+        bboxes_step_2,
+        labels_step_2,
+        scores_step_2,
+        format="tlbr",
+    )
+
+    file_path = tmp_dir / live.plots_dir / BoundingBoxes.subfolder / "image.json"
+
+    with open(file_path) as json_file:
+        file_content = json.load(json_file)
+
+    expected_bboxes = dict(zip(["top", "left", "bottom", "right"], bboxes_step_2[0]))
+    assert file_content["boxes"][0]["box"] == expected_bboxes
+    assert file_content["boxes"][0]["label"] == labels_step_2[0]
+    assert file_content["boxes"][0]["score"] == scores_step_2[0]
+
+
+def test_cleanup(tmp_dir):
+    live = Live()
+    live.log_bounding_boxes(
+        "image.json",
+        [[0, 0, 10, 10]],
+        ["cat"],
+        [0.2],
+        format="tlbr",
+    )
+    assert (tmp_dir / live.plots_dir / BoundingBoxes.subfolder / "image.json").exists()
+
+    Live()
+
+    assert not (tmp_dir / live.plots_dir / BoundingBoxes.subfolder).exists()
+
+
+@pytest.mark.parametrize("cache", [False, True])
+def test_cache_images(tmp_dir, dvc_repo, cache):
+    live = Live(save_dvc_exp=False, cache_images=cache)
+    live.log_bounding_boxes(
+        "image.json",
+        [[0, 0, 10, 10]],
+        ["cat"],
+        [0.2],
+        format="tlbr",
+    )
+    live.end()
+    assert (tmp_dir / "dvclive" / "plots" / "images.dvc").exists() == cache
+
+
+@pytest.mark.parametrize(
+    ("bounding_boxes", "format", "expected_result"),
+    [
+        ([[10, 20, 30, 40]], "tlbr", [[10, 20, 30, 40]]),
+        (
+            [[10, 20, 30, 40], [100, 200, 300, 400]],
+            "tlbr",
+            [[10, 20, 30, 40], [100, 200, 300, 400]],
+        ),
+        ([[10, 20, 30, 40]], "tlhw", [[10, 20, 40, 60]]),
+        (
+            [[10, 20, 30, 40], [100, 200, 300, 400]],
+            "tlhw",
+            [[10, 20, 40, 60], [100, 200, 400, 600]],
+        ),
+        ([[20, 30, 30, 40]], "xywh", [[5, 10, 35, 50]]),
+        ([[20, 30, 31, 41]], "xywh", [[4, 9, 35, 50]]),
+        (
+            [[20, 30, 30, 40], [200, 300, 300, 400]],
+            "xywh",
+            [[5, 10, 35, 50], [50, 100, 350, 500]],
+        ),
+    ],
+)
+def test_tlbr_conversion(bounding_boxes, format, expected_result):  # noqa: A002
+    assert expected_result == BoundingBoxes.convert_to_tlbr(bounding_boxes, format)


### PR DESCRIPTION
Add the possibility of logging bounding boxes in DVCLive!

Context: 
- https://github.com/iterative/dvc/issues/10198
- https://github.com/iterative/dvclive/issues/766

The current implementation uses the `log_bounding_boxes` function to save a JSON file that should be close to the image and with the same name. The format for the JSON file is:
```json
{
  "boxes": [
    {"label": "cat", "box": {"left": 100, "right": 110, "top": 5, "bottom": 20}, "score": 0.3},
    {"label": "dog", "box": {"left": 200, "right": 210, "top": 100, "bottom": 150}, "score": 0.4},
    {"label": "cat", "box": {"left": 300, "right": 310, "top": 200, "bottom": 300}, "score": 0.5}
    ]
}
```

The JSON format is still under discussion [here](https://github.com/iterative/dvc/issues/10198), so I consider the PR as a draft.



- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.
- [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.


