### PR TITLE
drop Python 3.8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
-          cache: 'pip'
+          python-version: "3.9"
+          cache: "pip"
           cache-dependency-path: setup.cfg
 
       - name: Upgrade pip
@@ -52,7 +52,7 @@ jobs:
 
       - name: mypy
         run: |
-           python -m mypy
+          python -m mypy
 
       - name: Run tests
         run: pytest -v tests --cov --cov-report=xml --cov-config=pyproject.toml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ["3.8", "3.9", "3.10"]
+        pyv: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Check out the repository
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyv }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: setup.cfg
 
       - name: Upgrade pip

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Request features on the `Issue Tracker`_.
 How to set up your development environment
 ------------------------------------------
 
-You need Python 3.8+.
+You need Python 3.9+.
 
 - Clone the repository:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Automation using nox."""
+
 import glob
 import os
 
@@ -9,7 +10,7 @@ nox.options.sessions = "lint", "tests"
 locations = "src", "tests"
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"])
 def tests(session: nox.Session) -> None:
     session.install(".[tests]")
     session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ keywords = [
 license = { text = "Apache License 2.0" }
 maintainers = [{ name = "Iterative", email = "support@dvc.org" }]
 authors = [{ name = "Iterative", email = "support@dvc.org" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

-----

Follow up to https://github.com/iterative/dvc/pull/10265. DVCLive can no longer support Python 3.8 as it depends on DVC and DVC dropped support in the aforementioned PR.