### PR TITLE
studio: add subdir to live metrics post messages to support live experiments in monorepos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "dvc>=3.33.3",
+  "dvc>=3.47.0",
   "dvc-render>=1.0.0,<2",
-  "dvc-studio-client>=0.17.1,<1",
+  "dvc-studio-client>=0.20,<1",
   "funcy",
   "gto",
   "ruamel.yaml",
-  "scmrepo"
+  "scmrepo>=3,<4"
 ]
 
 [project.optional-dependencies]

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     import PIL
 
 from dvc.exceptions import DvcException
+from dvc.utils.studio import get_subrepo_relpath
 from funcy import set_in
 from ruamel.yaml.representer import RepresenterError
 
@@ -141,6 +142,7 @@ class Live:
         self._baseline_rev: str = os.getenv(env.DVC_EXP_BASELINE_REV, NULL_SHA)
         self._exp_name: Optional[str] = exp_name or os.getenv(env.DVC_EXP_NAME)
         self._exp_message: Optional[str] = exp_message
+        self._subdir: Optional[str] = None
         self._experiment_rev: Optional[str] = None
         self._inside_dvc_exp: bool = False
         self._inside_dvc_pipeline: bool = False
@@ -239,6 +241,8 @@ class Live:
 
         if self._inside_dvc_pipeline:
             return
+
+        self._subdir = get_subrepo_relpath(self._dvc_repo)
 
         if self._save_dvc_exp:
             mark_dvclive_only_started(self._exp_name)

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -96,13 +96,16 @@ def get_dvc_studio_config(live: Live):
     return get_studio_config(dvc_studio_config=config)
 
 
-def post_to_studio(live: Live, event: Literal["start", "data", "done"]):
+def post_to_studio(live: Live, event: Literal["start", "data", "done"]):  # noqa: C901
     if event in live._studio_events_to_skip:
         return
 
     kwargs = {}
-    if event == "start" and live._exp_message:
-        kwargs["message"] = live._exp_message
+    if event == "start":
+        if message := live._exp_message:
+            kwargs["message"] = message
+        if subdir := live._subdir:
+            kwargs["subdir"] = subdir
     elif event == "data":
         metrics, params, plots = get_studio_updates(live)
         kwargs["step"] = live.step  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import sys
 import pytest
 from dvc_studio_client.env import DVC_STUDIO_TOKEN, DVC_STUDIO_URL, STUDIO_REPO_URL
 
+from dvclive.utils import rel_path
+
 
 @pytest.fixture()
 def tmp_dir(tmp_path, monkeypatch):
@@ -19,10 +21,17 @@ def mocked_dvc_repo(tmp_dir, mocker):
     _dvc_repo.scm.get_ref.return_value = None
     _dvc_repo.scm.no_commits = False
     _dvc_repo.experiments.save.return_value = "e" * 40
-    _dvc_repo.root_dir = tmp_dir
+    _dvc_repo.root_dir = _dvc_repo.scm.root_dir = tmp_dir
+    _dvc_repo.fs.relpath = rel_path
     _dvc_repo.config = {}
     mocker.patch("dvclive.live.get_dvc_repo", return_value=_dvc_repo)
     return _dvc_repo
+
+
+@pytest.fixture()
+def mocked_dvc_subrepo(tmp_dir, mocker, mocked_dvc_repo):
+    mocked_dvc_repo.root_dir = tmp_dir / "subdir"
+    return mocked_dvc_repo
 
 
 @pytest.fixture()

--- a/tests/test_post_to_studio.py
+++ b/tests/test_post_to_studio.py
@@ -81,6 +81,18 @@ def test_post_to_studio(tmp_dir, mocked_dvc_repo, mocked_studio_post):
     )
 
 
+def test_post_to_studio_subrepo(tmp_dir, mocked_dvc_subrepo, mocked_studio_post):
+    live = Live()
+    live.log_param("fooparam", 1)
+
+    mocked_post, _ = mocked_studio_post
+
+    mocked_post.assert_called_with(
+        "https://0.0.0.0/api/live",
+        **get_studio_call("start", exp_name=live._exp_name, subdir="subdir"),
+    )
+
+
 def test_post_to_studio_failed_data_request(
     tmp_dir, mocker, mocked_dvc_repo, mocked_studio_post
 ):


### PR DESCRIPTION
- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

----

Part of https://github.com/iterative/studio/issues/8848

Repeat of https://github.com/iterative/dvclive/pull/779 but stripped back to only send subdir. 

Depends on https://github.com/iterative/dvc-studio-client/pull/154 / https://github.com/iterative/studio/pull/9173 /https://github.com/iterative/dvc/pull/10303