### PR TITLE
Add internal counters to send only the latest datapoints to studio

### DIFF
--- a/src/dvclive/lightning.py
+++ b/src/dvclive/lightning.py
@@ -71,11 +71,6 @@ class DVCLiveLogger(Logger, FabricDVCLiveLogger):
         sync: Optional[bool] = False,
     ) -> None:
         if not sync and _should_sync():
-            if step == self.experiment._latest_studio_step:  # noqa: SLF001
-                # We are in log_eval_end_metrics but there has been already
-                # a studio request sent with `step`.
-                # We decrease the number to bypass `live.studio._get_unsent_datapoints`
-                self.experiment._latest_studio_step -= 1  # noqa: SLF001
             sync = True
         super().log_metrics(metrics, step, sync)
 

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -160,7 +160,6 @@ class Live:
         self._studio_events_to_skip: Set[str] = set()
         self._dvc_studio_config: Dict[str, Any] = {}
         self._num_points_sent_to_studio: Dict[str, int] = {}
-        self._num_points_read_from_file: Dict[str, int] = {}
         self._init_studio()
 
     def _init_resume(self):

--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -159,6 +159,8 @@ class Live:
         self._latest_studio_step = self.step if resume else -1
         self._studio_events_to_skip: Set[str] = set()
         self._dvc_studio_config: Dict[str, Any] = {}
+        self._num_points_sent_to_studio: Dict[str, int] = {}
+        self._num_points_read_from_file: Dict[str, int] = {}
         self._init_studio()
 
     def _init_resume(self):

--- a/src/dvclive/studio.py
+++ b/src/dvclive/studio.py
@@ -13,10 +13,6 @@ from dvclive.utils import parse_metrics, rel_path
 logger = logging.getLogger("dvclive")
 
 
-def _get_unsent_datapoints(plot, latest_step):
-    return [x for x in plot if int(x["step"]) > latest_step]
-
-
 def _cast_to_numbers(datapoints):
     for datapoint in datapoints:
         for k, v in datapoint.items():
@@ -37,11 +33,6 @@ def _adapt_path(live, name):
     if live._dvc_repo is not None:
         name = rel_path(name, live._dvc_repo.root_dir)
     return name
-
-
-def _adapt_plot_datapoints(live, plot):
-    datapoints = _get_unsent_datapoints(plot, live._latest_studio_step)
-    return _cast_to_numbers(datapoints)
 
 
 def _adapt_image(image_path):
@@ -71,15 +62,18 @@ def get_studio_updates(live):
     metrics_file = _adapt_path(live, metrics_file)
     metrics = {metrics_file: {"data": metrics}}
 
-    plots = {
-        _adapt_path(live, name): _adapt_plot_datapoints(live, plot)
-        for name, plot in plots.items()
-    }
-    plots = {k: {"data": v} for k, v in plots.items()}
+    plots_to_send = {}
+    live._num_points_read_from_file = {}
+    for name, plot in plots.items():
+        path = _adapt_path(live, name)
+        nb_points_already_sent = live._num_points_sent_to_studio.get(path, 0)
+        plots_to_send[path] = _cast_to_numbers(plot[nb_points_already_sent:])
+        live._num_points_read_from_file.update({path: len(plot)})
 
-    plots.update(_adapt_images(live))
+    plots_to_send = {k: {"data": v} for k, v in plots_to_send.items()}
+    plots_to_send.update(_adapt_images(live))
 
-    return metrics, params, plots
+    return metrics, params, plots_to_send
 
 
 def get_dvc_studio_config(live):
@@ -120,6 +114,8 @@ def post_to_studio(live, event):
             live._studio_events_to_skip.add("data")
             live._studio_events_to_skip.add("done")
     elif event == "data":
+        for path, num_points in live._num_points_read_from_file.items():
+            live._num_points_sent_to_studio[path] = num_points
         live._latest_studio_step = live.step
 
     if event == "done":

--- a/tests/frameworks/test_lightning.py
+++ b/tests/frameworks/test_lightning.py
@@ -1,4 +1,6 @@
 import os
+import threading
+import time
 from contextlib import redirect_stdout
 from io import StringIO
 from unittest import mock
@@ -268,7 +270,6 @@ class ValLitXOR(LitXOR):
 
 
 def test_lightning_val_updates_to_studio(tmp_dir, mocked_dvc_repo, mocked_studio_post):
-    """Test the `self.experiment._latest_studio_step -= 1` logic."""
     mocked_post, _ = mocked_studio_post
 
     model = ValLitXOR()
@@ -286,8 +287,7 @@ def test_lightning_val_updates_to_studio(tmp_dir, mocked_dvc_repo, mocked_studio
     logs, _ = parse_metrics(dvclive_logger.experiment)
     latest = logs[val_loss][-1]
     calls = mocked_post.call_args_list
-    # Without `self.experiment._latest_studio_step -= 1`
-    # Latest data would not be posted
+
     latest_called = False
     for call in calls:
         try:
@@ -350,3 +350,53 @@ def test_dvclive_logger_init_args():
             "dir": "results",  # Resolve from Live.__init__
         },
     )
+
+
+def log_metrics_from_outside_lightning(live):
+    step = 0
+    while True:
+        if live.step == step:
+            live.log_metric("test", 0.5)
+            step += 1
+        else:
+            time.sleep(0.001)
+
+
+@pytest.mark.timeout(3)
+def test_metrics_from_outside_lightning_updates_to_studio(
+    tmp_dir, mocked_dvc_repo, mocked_studio_post
+):
+    mocked_post, _ = mocked_studio_post
+
+    model = ValLitXOR()
+    dvclive_logger = DVCLiveLogger()
+    trainer = Trainer(
+        logger=dvclive_logger,
+        max_steps=4,
+        val_check_interval=2,
+        log_every_n_steps=1,
+        enable_checkpointing=False,
+    )
+
+    independent_logger = threading.Thread(
+        target=log_metrics_from_outside_lightning,
+        args=(trainer.logger.experiment,),
+        daemon=True,
+    )
+    independent_logger.start()
+    trainer.fit(model)
+
+    test_metric = "dvclive/plots/metrics/test.tsv"
+    logs, _ = parse_metrics(dvclive_logger.experiment)
+    calls = mocked_post.call_args_list
+
+    data_calls = [call for call in calls if call[1]["json"]["type"] == "data"]
+
+    test_calls = []
+    # data are sent twice, using 2 `post` calls in `post_live_metrics`.
+    for call in data_calls[::2]:
+        test_calls.extend(call[1]["json"]["plots"][test_metric]["data"])
+
+    # data read from file is read as str
+    test_calls = [{k: str(v) for k, v in data.items()} for data in test_calls]
+    assert test_calls == logs[test_metric]

--- a/tests/test_post_to_studio.py
+++ b/tests/test_post_to_studio.py
@@ -464,3 +464,17 @@ def test_post_to_studio_skip_if_no_repo_url(
         live.next_step()
 
     assert mocked_post.call_count == 0
+
+
+def test_post_to_studio_increment_internal_state(
+    tmp_dir, mocked_dvc_repo, mocked_studio_post
+):
+    live = Live()
+    foo_path = (Path(live.plots_dir) / Metric.subfolder / "foo.tsv").as_posix()
+
+    live.log_metric("foo", 1)
+    live.make_summary()  # required for `post_to_studio`
+    assert live._num_points_sent_to_studio == {}
+
+    live.post_to_studio("data")
+    assert live._num_points_sent_to_studio == {foo_path: 1}

--- a/tests/test_post_to_studio.py
+++ b/tests/test_post_to_studio.py
@@ -467,6 +467,7 @@ def test_post_to_studio_skip_if_no_repo_url(
 
 
 def test_post_to_studio_repeat_step(tmp_dir, mocked_dvc_repo, mocked_studio_post):
+    # for more context see the PR https://github.com/iterative/dvclive/pull/788
     live = Live()
 
     foo_path = (Path(live.plots_dir) / Metric.subfolder / "foo.tsv").as_posix()

--- a/tests/test_post_to_studio.py
+++ b/tests/test_post_to_studio.py
@@ -464,17 +464,3 @@ def test_post_to_studio_skip_if_no_repo_url(
         live.next_step()
 
     assert mocked_post.call_count == 0
-
-
-def test_post_to_studio_increment_internal_state(
-    tmp_dir, mocked_dvc_repo, mocked_studio_post
-):
-    live = Live()
-    foo_path = (Path(live.plots_dir) / Metric.subfolder / "foo.tsv").as_posix()
-
-    live.log_metric("foo", 1)
-    live.make_summary()  # required for `post_to_studio`
-    assert live._num_points_sent_to_studio == {}
-
-    live.post_to_studio("data")
-    assert live._num_points_sent_to_studio == {foo_path: 1}


### PR DESCRIPTION
Following a bug detected during [this feature](https://github.com/iterative/dvclive/pull/773) development.

Using the `step` value to send the latest data to Studio can lead to weird behavior because the `step` is poorly defined in some loggers (eg. pytorch lightning logger). Because the step definition is poorly defined in lightning we used a hack to ensure the `log_metrics` calls by the lightning trainer were correct. But calling `log_metrics` from outside the lightning trainer (a separate thread for instance) leads to data not being sent to Studio or duplicates data. 

This PR introduces a counter for each metric that increments when Studio receives the data points. Instead of using the `step` property as a proxy for which data has been sent to studio, we literally count them now. This way, when we want to send data points to Studio, we can only send the points it hasn't received yet.

The test added in the PR fails in the `main` branch because `logs[test_metric]` is 
```python
[
    {'step': '0', 'test': '0.5'}, 
    {'step': '1', 'test': '0.5'}, 
    {'step': '2', 'test': '0.5'}, 
    {'step': '3', 'test': '0.5'}
]
```
which is expected. But `test_calls` is 
```python
[
    {'step': '0', 'test': '0.5'}, 
    {'step': '1', 'test': '0.5'},
    {'step': '1', 'test': '0.5'}, 
    {'step': '1', 'test': '0.5'},
    {'step': '2', 'test': '0.5'}, 
    {'step': '3', 'test': '0.5'},
    {'step': '3', 'test': '0.5'}
]
```

With this PR, both values `logs[test_metric]` and `test_calls` are the same and don't contain duplicated elements.

- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

