### PR TITLE
Align JSON/YAML indentation settings better with common formatting styles

### DIFF
--- a/src/dvclive/serialize.py
+++ b/src/dvclive/serialize.py
@@ -45,7 +45,7 @@ def dump_yaml(content, output_file):
         yaml.dump(content, fd)
 
 
-def dump_json(content, output_file, indent=4, **kwargs):
+def dump_json(content, output_file, indent=2, **kwargs):
     make_dir(output_file)
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(content, f, indent=indent, **kwargs)

--- a/src/dvclive/serialize.py
+++ b/src/dvclive/serialize.py
@@ -31,6 +31,7 @@ def get_yaml():
 
     yaml = YAML()
     yaml.default_flow_style = False
+    yaml.indent(mapping=2, sequence=4, offset=2)
 
     # tell Dumper to represent OrderedDict as normal dict
     yaml_repr_cls = yaml.Representer


### PR DESCRIPTION
Just a minor esthetics change: I've updated the indentation settings for JSON and YAML to align better with common formatting styles.

JSON is commonly indented with 2 spaces and not 4. 2 spaces also reduces storage and bandwidth waste a little.

YAML is often formatted with a 2 spaces offset for lists. For instance, Prettier formats it like this.

```diff
 k:
-- 1
+  - 1
-- 2
+  - 2
```

Also, `ruamel.yaml`'s documentation states:

> The above example with the often seen `yaml.indent(mapping=2, sequence=4, offset=2)` indentation:
>
> ```yaml
> x:
>   y:
>     - b: 1
>     - 2
> ```
>
> &mdash; https://yaml.readthedocs.io/en/latest/detail/#indentation-of-block-sequences

---

- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.