### PR TITLE
fix(studio): wait for studio metrics publish to complete on end

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -905,6 +905,11 @@ class Live:
 
         self._studio_queue.put(self)
 
+    def _wait_for_studio_updates_posted(self):
+        if self._studio_queue:
+            logger.debug("Waiting for studio updates to be posted")
+            self._studio_queue.join()
+
     def end(self):
         """
         Signals that the current experiment has ended.
@@ -945,6 +950,8 @@ class Live:
                 )
 
         self.save_dvc_exp()
+
+        self._wait_for_studio_updates_posted()
 
         # Mark experiment as done
         post_to_studio(self, "done")


### PR DESCRIPTION
W/o this fix in the `example-get-started-experiments` we are not getting images published to Studio (it doesn't have time to complete, `evaluate` exits faster).

--------------

- [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
