### PR TITLE
Fix: Empty string as template in CustomPlot.init

### DIFF
--- a/src/dvclive/plots/custom.py
+++ b/src/dvclive/plots/custom.py
@@ -23,7 +23,7 @@ class CustomPlot(Data):
     ) -> None:
         super().__init__(name, output_folder)
         self.name = self.name.replace(".json", "")
-        if template.strip() == "":
+        if template is not None and template.strip() == "":
             template = None
 
         config = {

--- a/src/dvclive/plots/custom.py
+++ b/src/dvclive/plots/custom.py
@@ -23,6 +23,9 @@ class CustomPlot(Data):
     ) -> None:
         super().__init__(name, output_folder)
         self.name = self.name.replace(".json", "")
+        if template.strip() == "":
+            template = None
+
         config = {
             "template": template,
             "x": x,

--- a/src/dvclive/plots/custom.py
+++ b/src/dvclive/plots/custom.py
@@ -23,7 +23,7 @@ class CustomPlot(Data):
     ) -> None:
         super().__init__(name, output_folder)
         self.name = self.name.replace(".json", "")
-        if template is not None and template.strip() == "":
+        if not template:
             template = None
 
         config = {

--- a/tests/plots/test_custom.py
+++ b/tests/plots/test_custom.py
@@ -83,3 +83,30 @@ def test_log_custom_plot_with_template_as_empty_string(tmp_dir):
         "x_label": "x_label",
         "y_label": "y_label",
     }
+
+
+def test_default_template_in_log_custom_plot(tmp_dir):
+    live = Live()
+    out = tmp_dir / live.plots_dir / CustomPlot.subfolder
+
+    datapoints = [{"x": 1, "y": 2}, {"x": 3, "y": 4}]
+    live.log_plot(
+        "custom_linear",
+        datapoints,
+        x="x",
+        y="y",
+        title="custom_title",
+        x_label="x_label",
+        y_label="y_label",
+    )
+
+    assert json.loads((out / "custom_linear.json").read_text()) == datapoints
+
+    assert live._plots["custom_linear"].plot_config == {
+        "template": "linear",
+        "title": "custom_title",
+        "x": "x",
+        "y": "y",
+        "x_label": "x_label",
+        "y_label": "y_label",
+    }

--- a/tests/plots/test_custom.py
+++ b/tests/plots/test_custom.py
@@ -84,29 +84,3 @@ def test_log_custom_plot_with_template_as_empty_string(tmp_dir):
         "y_label": "y_label",
     }
 
-
-def test_default_template_in_log_custom_plot(tmp_dir):
-    live = Live()
-    out = tmp_dir / live.plots_dir / CustomPlot.subfolder
-
-    datapoints = [{"x": 1, "y": 2}, {"x": 3, "y": 4}]
-    live.log_plot(
-        "custom_linear",
-        datapoints,
-        x="x",
-        y="y",
-        title="custom_title",
-        x_label="x_label",
-        y_label="y_label",
-    )
-
-    assert json.loads((out / "custom_linear.json").read_text()) == datapoints
-
-    assert live._plots["custom_linear"].plot_config == {
-        "template": "linear",
-        "title": "custom_title",
-        "x": "x",
-        "y": "y",
-        "x_label": "x_label",
-        "y_label": "y_label",
-    }

--- a/tests/plots/test_custom.py
+++ b/tests/plots/test_custom.py
@@ -56,3 +56,30 @@ def test_log_custom_plot_multi_y(tmp_dir):
         "x_label": "x_label",
         "y_label": "y_label",
     }
+
+
+def test_log_custom_plot_with_template_as_empty_string(tmp_dir):
+    live = Live()
+    out = tmp_dir / live.plots_dir / CustomPlot.subfolder
+
+    datapoints = [{"x": 1, "y": 2}, {"x": 3, "y": 4}]
+    live.log_plot(
+        "custom_linear",
+        datapoints,
+        x="x",
+        y="y",
+        template="",
+        title="custom_title",
+        x_label="x_label",
+        y_label="y_label",
+    )
+
+    assert json.loads((out / "custom_linear.json").read_text()) == datapoints
+    # 'template' should not be in plot_config. Default template will be assigned later.
+    assert live._plots["custom_linear"].plot_config == {
+        "title": "custom_title",
+        "x": "x",
+        "y": "y",
+        "x_label": "x_label",
+        "y_label": "y_label",
+    }

--- a/tests/plots/test_custom.py
+++ b/tests/plots/test_custom.py
@@ -83,4 +83,3 @@ def test_log_custom_plot_with_template_as_empty_string(tmp_dir):
         "x_label": "x_label",
         "y_label": "y_label",
     }
-


### PR DESCRIPTION
Fixes #10482 (report in dvc repo) at https://github.com/iterative/dvc/issues/10482

- [x] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
