### PR TITLE
Fix local variable 'last_metrics' referenced before assignment

### DIFF
--- a/src/dvclive/monitor_system.py
+++ b/src/dvclive/monitor_system.py
@@ -117,6 +117,7 @@ class _SystemMonitor:
     def _monitoring_loop(self):
         while not self._shutdown_event.is_set():
             self._metrics = {}
+            last_metrics = {}
             for _ in range(self._num_samples):
                 try:
                     last_metrics = self._get_metrics()


### PR DESCRIPTION
This happens on line :132 in case of handled exception in the first iteration of the loop.