### PR TITLE
fix(studio): handle unexpected exceptions in updates thread

### DIFF
--- a/src/dvclive/live.py
+++ b/src/dvclive/live.py
@@ -929,10 +929,17 @@ class Live:
             self._studio_queue = queue.Queue()
 
             def worker():
+                error_occurred = False
                 while True:
                     item, data = self._studio_queue.get()
-                    post_to_studio(item, "data", data)
-                    self._studio_queue.task_done()
+                    try:
+                        if not error_occurred:
+                            post_to_studio(item, "data", data)
+                    except Exception:
+                        logger.exception("Failed to post data to studio")
+                        error_occurred = True
+                    finally:
+                        self._studio_queue.task_done()
 
             threading.Thread(target=worker, daemon=True).start()
 


### PR DESCRIPTION
Continuation of https://github.com/iterative/dvclive/pull/860

Fixes #858 

We catch properly unexpected exceptions in Studio updates thread and continue consuming from the queue (to make it empty so `join` below doesn't hang). 

## TODO:

- [x] Add test

--------------------

- [X] ❗ I have followed the [Contributing to DVCLive](https://github.com/iterative/dvclive/blob/main/CONTRIBUTING.rst) guide.

- [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
