### PR TITLE
deps: replace deprecated pynvml with nvidia-ml-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "ruamel.yaml",
   "scmrepo>=3,<4",
   "psutil",
-  "pynvml"
+  "nvidia-ml-py"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`dvclive` declares `pynvml` as a dependency. The `pynvml` PyPI package is [deprecated](https://pypi.org/project/pynvml/) — v13.x is just a shim that redirects to the official NVIDIA bindings (`nvidia-ml-py`) and emits a `FutureWarning` on import:

> The pynvml package is deprecated. Please install nvidia-ml-py instead.

Both packages ship a `pynvml.py` at the same path, so resolving `pynvml` 13.x produces a warning that downstream consumers running with `filterwarnings=error` (e.g. datachain/studio test suites) escalate to a hard error during collection.

## Fix

Depend on `nvidia-ml-py` directly. It provides the same `pynvml` module (`nvmlInit`, `nvmlDeviceGetCount`, etc.), so the existing `from pynvml import ...` in `monitor_system.py` keeps working unchanged — without the deprecated shim and its `FutureWarning`.

## Verification

- `nvidia-ml-py` alone (with `pynvml` uninstalled) provides all imported symbols.
- `import pynvml` under `-W error::FutureWarning` no longer raises.
- `tests/test_monitor_system.py` passes (8/8) with `FutureWarning` treated as an error.